### PR TITLE
update .zsh_plugins.txt for antidote

### DIFF
--- a/dot_zsh_plugins.txt
+++ b/dot_zsh_plugins.txt
@@ -1,5 +1,9 @@
 # .zsh_plugins.txt - comments begin with "#"
 
+# This is used by antidote. Do you have it?
+# brew install antidote
+# ref: https://antidote.sh/
+
 # Basic Zsh plugins are defined in user/repo format
 zsh-users/zsh-autosuggestions
 zdharma-continuum/fast-syntax-highlighting

--- a/dot_zsh_plugins.txt
+++ b/dot_zsh_plugins.txt
@@ -9,3 +9,9 @@ zdharma-continuum/fast-syntax-highlighting
 
 agkozak/zsh-z
 mattmc3/ez-compinit
+
+# normal vi mode in ZSH sucks.
+jeffreytse/zsh-vi-mode
+
+# replace aliases with abbreviations.
+#olets/zsh-abbr

--- a/dot_zsh_plugins.txt
+++ b/dot_zsh_plugins.txt
@@ -5,7 +5,7 @@
 
 # Basic Zsh plugins are defined in user/repo format
 zsh-users/zsh-autosuggestions
-zdharma-continuum/fast-syntax-highlighting
+zdharma-continuum/fast-syntax-highlighting kind:defer
 
 agkozak/zsh-z
 mattmc3/ez-compinit
@@ -14,4 +14,4 @@ mattmc3/ez-compinit
 jeffreytse/zsh-vi-mode
 
 # replace aliases with abbreviations.
-#olets/zsh-abbr
+#olets/zsh-abbr kind:defer

--- a/dot_zsh_plugins.txt
+++ b/dot_zsh_plugins.txt
@@ -1,7 +1,6 @@
 # .zsh_plugins.txt - comments begin with "#"
 
 # This is used by antidote. Do you have it?
-# brew install antidote
 # ref: https://antidote.sh/
 
 # Basic Zsh plugins are defined in user/repo format
@@ -10,6 +9,3 @@ zdharma-continuum/fast-syntax-highlighting
 
 agkozak/zsh-z
 mattmc3/ez-compinit
-
-# The following is replaced by atuin
-# zsh-users/zsh-history-substring-search

--- a/dot_zsh_plugins.txt
+++ b/dot_zsh_plugins.txt
@@ -15,3 +15,6 @@ jeffreytse/zsh-vi-mode
 
 # replace aliases with abbreviations.
 #olets/zsh-abbr kind:defer
+
+# clear history when you go $HOME.
+givensuman/zsh-allclear

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -51,11 +51,8 @@ if [[ -d $HOME/.atuin/bin ]] then
   eval "$(atuin init zsh)"
 fi
 
-if type antidote &>/dev/null
-then
-  source $(brew --prefix)/opt/antidote/share/antidote/antidote.zsh
-  antidote load
-fi
+# Antidote: the cure to slow zsh plugin management (https://antidote.sh)
+source $(brew --prefix)/opt/antidote/share/antidote/antidote.zsh &>/dev/null && antidote load
 
 # Starship: Cross-Shell Prompt (https://starship.rs/)
 if [[ $(command -v starship) ]] then


### PR DESCRIPTION
Fixes #10.

Antidote was not working because I was checking `type antidote` which doesn't work because it is a shell function that gets sourced.

Updated .zshrc to attempt to source the file, or do nothing if it can't be found.
Re-added .zsh_plugins.txt and added a few goodies.