### PR TITLE
.envrc for DataRobot

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -19,3 +19,8 @@ Library/Preferences
 # ignore non-Windows files.
 {{ if ne .chezmoi.os "windows" -}}
 {{- end }}
+
+# Ignore work files.
+{{- if not .dr }}
+workspace/DataRobot
+{{- end }}

--- a/workspace/DataRobot/dot_envrc
+++ b/workspace/DataRobot/dot_envrc
@@ -1,0 +1,5 @@
+# working in DataRobot always needs this
+export PYTHONPATH=`pwd`
+
+# set virtualenv to the latest DataRobot
+export VIRTUAL_ENV=~/.virtualenvs/datarobot


### PR DESCRIPTION
add .envrc to set PYTHONPATH per dev-docs, but don't include this when standing up a non-work machine