### PR TITLE
Add global gitignore

### DIFF
--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -3,6 +3,7 @@
 	email = {{ .email }}
 [core]
         editor = zed --wait
+        excludesFile = ~/.gitignore
 [init]
         defaultBranch = main
 [pull]

--- a/dot_gitignore
+++ b/dot_gitignore
@@ -1,0 +1,3 @@
+# ignore .envrc used by direnv
+# as this should always be my own work
+.envrc


### PR DESCRIPTION
Since I started use direnv I've had this really annoying setup where my .envrc pollutes `git status`. I've also lost this file once or twice when I `git clean -f .`.

Globally gitignore this now so it doesn't become a problem.