### PR TITLE
feat(zshrc,profile): conditionally source LM Studio CLI when installed

### DIFF
--- a/dot_profile
+++ b/dot_profile
@@ -3,3 +3,8 @@
 # to my history outside of zsh.
 . "$HOME/.atuin/bin/env"
 . "$HOME/.local/bin/env"
+
+# LM Studio CLI (lms): only add to PATH if installed
+if [ -d "$HOME/.lmstudio/bin" ]; then
+  export PATH="$PATH:$HOME/.lmstudio/bin"
+fi

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -96,3 +96,8 @@ export PATH="$HOME/.local/bin:$PATH"
 
 # Added by Cargo
 export PATH="$HOME/.cargo/bin:$PATH"
+
+# LM Studio CLI (lms): only add to PATH if installed
+if [[ -d "$HOME/.lmstudio/bin" ]] then
+  export PATH="$PATH:$HOME/.lmstudio/bin"
+fi


### PR DESCRIPTION
Wrap the LM Studio PATH export in an install guard (-d $HOME/.lmstudio/bin) so it is only loaded when LM Studio is present. Previously the line was written unconditionally by lms into ~/.zshrc and ~/.profile, which leaked into chezmoi's live state without a corresponding source entry.