### PR TITLE
feat(git): add a worktree-aware git status

### DIFF
--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -26,7 +26,7 @@
 [checkout]
         defaultRemote = origin
 [alias]
-        st = status
+        st = wstatus
         co = checkout
         ci = commit
         cp = cherry-pick
@@ -67,7 +67,6 @@
         # https://hackernoon.com/lesser-known-git-commands-151a1918a60
         please = push --force-with-lease
         commend = commit --amend --no-edit
-        st = status -sb -uall
         grog = log --graph --abbrev-commit --decorate --all --format=format:\"%C(bold blue)%h%C(reset) - %C(bold cyan)%aD%C(dim white) - %an%C(reset) %C(bold green)(%ar)%C(reset)%C(bold yellow)%d%C(reset)%n %C(white)%s%C(reset)\"
 
         # @jmbledsoe

--- a/dot_local/bin/executable_git-wstatus
+++ b/dot_local/bin/executable_git-wstatus
@@ -1,0 +1,52 @@
+#!/bin/sh
+# git status, but falls back to a one-line-per-worktree summary when plain
+# `git status` can't run (e.g. "fatal: this operation must be run in a
+# worktree", which happens e.g. when cwd is the bare .git dir of a repo with
+# multiple linked worktrees).
+#
+# Normal case: behaves exactly like `git status -sb -uall`.
+# Fallback case: one line per worktree, sorted dirty-first. Paths are shown
+# relative to the current directory.
+
+out=$(git status -sb -uall 2>&1)
+rc=$?
+
+if [ "$rc" -eq 0 ]; then
+	printf '%s\n' "$out"
+	exit 0
+fi
+
+if ! printf '%s' "$out" | grep -q 'must be run in a work'; then
+	# Some other failure (e.g. not a git repo at all) -- surface it as-is.
+	printf '%s\n' "$out" >&2
+	exit "$rc"
+fi
+
+tab=$(printf '\t')
+
+git worktree list --porcelain | awk '/^worktree /{print $2}' | while IFS= read -r wt; do
+	rel=$(perl -MFile::Spec -e 'print File::Spec->abs2rel($ARGV[0])' "$wt")
+
+	if [ ! -d "$wt" ]; then
+		printf '1\t%-60s %-14s %s\n' "$rel" "missing" "(prunable, run: git worktree prune)"
+		continue
+	fi
+
+	# Unset GIT_DIR/GIT_WORK_TREE/GIT_INDEX_FILE: git sets these for alias
+	# shell commands, and they leak into `-C` invocations otherwise, making
+	# every worktree report the same (wrong) branch/status.
+	env -u GIT_DIR -u GIT_WORK_TREE -u GIT_INDEX_FILE \
+		git -C "$wt" status --porcelain=v2 --branch 2>/dev/null |
+		awk -v wt="$rel" '
+			/^# branch\.oid/ { oid = $3 }
+			/^# branch\.head/ { branch = $3 }
+			/^[12u?]/ { dirty++ }
+			END {
+				detached = (branch == "" || branch == "(detached)")
+				dirty_key = dirty ? 0 : 1
+				status = dirty ? dirty" change(s)" : "clean"
+				ref = detached ? "(detached @ " substr(oid, 1, 7) ")" : branch
+				printf "%d\t%-60s %-14s %s\n", dirty_key, wt, status, ref
+			}
+		'
+done | sort -t "$tab" -k1,1n -s | cut -f2-


### PR DESCRIPTION
```sh
╰─ ❯ g st           
../.claude/worktrees/hardcore-edison-5a4867                  1 change(s)    claudy/hardcore-edison-5a4867
..                                                           clean          main
../../CFX-6917_deps_install_for_windows                      clean          CFX-6917_deps_install_for_windows
../../cli-phase1                                             clean          aj/CFX-6647-remote-signed-ps1
../../cli-phase2                                             clean          aj/CFX-6647-phase2
../../cli-plugin-docs                                        clean          aj/more-cli-plugin-docs
../../cli-pr691                                              clean          chas/CFX-6984
../../cli-pr710                                              clean          pr-710
../../cli-pr711                                              clean          aj/lint-windows-build-tags
../.aj/cfx-5253                                              clean          cfx-5253
../.aj/worktrees/cli-review                                  clean          (detached @ 754db5e)
../.aj/worktrees/pr-607-review                               clean          pr-607
../.aj/worktrees/pr-625-review                               clean          (detached @ 3124498)
../.aj/worktrees/pr-701-review                               clean          pr-701
../.claude/worktrees/admiring-archimedes-3ca7af              clean          claudy/cli-architecture-diagrams-82a66f
../.claude/worktrees/agentmemory-fork-config-b2e8bb          clean          (detached @ f0751b0)
../.claude/worktrees/competent-mccarthy-2449ad               clean          (detached @ 4b915e8)
../.claude/worktrees/dreamy-babbage-821d7b                   clean          (detached @ a26420a)
../.claude/worktrees/frosty-kepler-01c387                    clean          (detached @ e9b7bc1)
../.claude/worktrees/insights-cad45c                         clean          claudy/insights-cad45c
../.claude/worktrees/musing-montalcini-e49eb9                clean          (detached @ 2d9845a)
../main                                                      missing        (prunable, run: git worktree prune)
```