### PR TITLE
docs(gitconfig): comment non-obvious aliases, add aliashelp

### DIFF
--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -34,11 +34,13 @@
 [fetch]
 	prune = true
 [alias]
+	# depends on external `wstatus` script/alias, not a built-in git command
 	st = wstatus
 	co = checkout
 	ci = commit
 	cp = cherry-pick
 	br = branch
+	# switch back to the previously checked out branch
 	nb = switch -
 	adp = add -p
 	cop = checkout -p -- .
@@ -51,21 +53,30 @@
 	# https://davidwalsh.name/get-default-branch-name
 	default-branch = !git remote show origin | grep 'HEAD branch' | cut -d' ' -f5
 	rebaseia = rebase -i --autosquash
+	# interactive autosquash rebase onto the repo's default branch
 	rebaseiam = !git rebase -i --autosquash $(git default-branch)
+	# safer force-push: aborts if the remote has commits you don't have locally
 	please = push --force-with-lease
 	praise = blame
 
 	# https://haacked.com/archive/2014/07/28/github-flow-aliases/
 	up = !git pull --rebase --prune $@ && git submodule update --init --recursive
 	cob = checkout -b
+	# stage everything and commit in one step
 	cm = !git add -A && git commit -m
+	# quick checkpoint commit of all changes
 	save = !git add -A && git commit -m 'SAVEPOINT'
 	wip = commit -am "WIP"
+	# uncommit the last commit, keeping its changes in the working tree (unstaged)
 	undo = reset HEAD~1 --mixed
 	amend = commit -a --amend
+	# destructive: snapshot everything, then hard-reset it away (the commit stays dangling as a safety net)
 	wipe = !git add -A && git commit -qm 'WIPE SAVEPOINT' && git reset HEAD~1 --hard
+	# checkout the default branch and delete local branches already merged into it
 	bclean = "!f() { git checkout ${1-$(git default-branch)} && git branch --merged ${1-$(git default-branch)} | grep -v " ${1-$(git default-branch)}$" | xargs git branch -d; }; f"
+	# pull the latest default branch, then run bclean — typical "finish a branch" cleanup
 	bdone = "!f() { git checkout ${1-$(git default-branch)} && git up && git bclean ${1-$(git default-branch)}; }; f"
+	# move the current branch's commits onto a new branch name and rebase onto a different base
 	migrate = "!f(){ CURRENT=$(git symbolic-ref --short HEAD); git checkout -b $1 && git branch --force $CURRENT ${3-$CURRENT@{u}} && git rebase --onto ${2-$(git default-branch)} $CURRENT; }; f"
 
 	# https://coderwall.com/p/euwpig/a-better-git-log
@@ -80,6 +91,11 @@
 	# squash = similar to 'git merge --squash', but without committing
 	trimdryrun = "!f() { git branch | grep -v '^\\*' | xargs cat; }; f"
 	trim = "!f() { git branch | grep -v '^\\*' | xargs git branch -D; }; f"
+	# soft-reset to the merge-base with the default branch, staging all commits since diverging (squash prep, no commit made)
 	squash = "!f() { git reset $(git merge-base ${1-$(git default-branch)} $(git rev-parse --abbrev-ref HEAD)); }; f"
 
+	# list the 10 most recently updated local branches, sorted by commit date
 	branchdate = for-each-ref --count=10 --sort=-committerdate refs/heads/ --format="%(authordate:short)%09%(objectname:short)%09%1B[0;33m%(refname:short)%1B[m%09"
+
+	# print the comment line(s) directly above `<name> = ...` in this config, e.g. `git aliashelp bclean`
+	aliashelp = "!f() { awk -v name=\"$1\" '/^\\t#/{c=c $0 \"\\n\"; next} $0 ~ (\"^\\t\"name\" =\"){printf \"%s\", c; exit} {c=\"\"}' ~/.gitconfig; }; f"


### PR DESCRIPTION
## Summary
- Add comments above the shell-function aliases whose behavior isn't obvious from the name alone (`bclean`, `bdone`, `migrate`, `squash`, `wipe`, `save`, `undo`, `cm`, `please`, `rebaseiam`, `st`, `nb`).
- Add a new `aliashelp` alias: `git aliashelp <name>` prints the comment sitting directly above that alias in the config (git aliases can't intercept `--help` themselves, so this is the closest equivalent).

## Test plan
- [x] `chezmoi apply ~/.gitconfig` and diffed the rendered output against a manually-edited copy — identical.
- [x] `git aliashelp bclean` / `git aliashelp squash` print the expected comments; `git aliashelp co` (no comment) prints nothing.
- [x] `git config -l -f ~/.gitconfig` still parses cleanly.