### PR TITLE
chore: fix compdef not being applied early enough

### DIFF
--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -47,6 +47,13 @@ then
   FPATH="$(brew --prefix)/share/zsh/site-functions:${FPATH}"
 fi
 
+# Initialize zsh completion system early, before any tool (atuin,
+# antidote plugins, etc.) emits `compdef` calls. Without this,
+# `eval "$(atuin gen-completions --shell zsh)"` fails with
+# "command not found: compdef".
+autoload -Uz compinit
+compinit
+
 # prepend Homebrew GNU coreutils to PATH (shadow BSD versions)
 # only active when the gnubin directories exist
 if type brew &>/dev/null
@@ -104,13 +111,10 @@ fi
 
 # The following lines have been added by Docker Desktop to enable Docker CLI completions.
 fpath=(/Users/aj.alon/.docker/completions $fpath)
-autoload -Uz compinit
-compinit
 # End of Docker CLI completions
 
 # Added by dr completion installer
 fpath=(/Users/aj.alon/.zsh/completions $fpath)
-autoload -U compinit && compinit
 
 # Added by n-install (see http://git.io/n-install-repo).
 export N_PREFIX="$HOME/n"; [[ :$PATH: == *":$N_PREFIX/bin:"* ]] || PATH+=":$N_PREFIX/bin"


### PR DESCRIPTION
## Problem

New zsh shells printed `command not found: compdef` on startup.

## Root cause

`compinit` was called twice at the bottom of `dot_zshrc.tmpl` (in the Docker and dr completion blocks), but `compdef` was already being invoked earlier by `eval "$(atuin gen-completions --shell zsh)"` and antidote plugins — before the completion system was initialized.

## Fix

Move `autoload -Uz compinit; compinit` to run once, early — right after the Homebrew `FPATH` setup and before any `compdef`-emitting tool. Remove the two duplicate `compinit` calls from the Docker and dr blocks (kept their `fpath=...` lines).