### PR TITLE
feat: make dotfiles cross-platform (Linux-tested on Bazzite-DX)

### DIFF
--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -22,6 +22,8 @@
 [credential]
 {{ if eq .chezmoi.os "darwin" }}
 	helper = osxkeychain
+{{ else }}
+	helper = store
 {{ end }}
 [checkout]
 	defaultRemote = origin

--- a/dot_profile.tmpl
+++ b/dot_profile.tmpl
@@ -1,10 +1,18 @@
 # This file is sourced by the shell at login.
 # atuin set this up so that I can have access
 # to my history outside of zsh.
+{{ if eq .chezmoi.os "darwin" -}}
 . "$HOME/.atuin/bin/env"
 . "$HOME/.local/bin/env"
+{{- end }}
 
 # LM Studio CLI (lms): only add to PATH if installed
 if [ -d "$HOME/.lmstudio/bin" ]; then
   export PATH="$PATH:$HOME/.lmstudio/bin"
+fi{{ if ne .chezmoi.os "darwin" }}
+
+# Linuxbrew: ensure Homebrew/Linuxbrew bins are on PATH for login shells on Linux.
+if [ -d /home/linuxbrew/.linuxbrew ]; then
+  eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
 fi
+{{ end }}

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -21,7 +21,7 @@ export HOMEBREW_NO_INSTALL_CLEANUP=1
 alias g="git"
 alias ll="ls -al"
 alias cm="chezmoi"
-alias edit="open"
+alias edit="{{ if eq .chezmoi.os "darwin" }}open{{ else }}xdg-open{{ end }}"
 alias k="kubectl"
 alias t="terraform"
 alias d="docker"
@@ -65,12 +65,19 @@ then
 fi
 
 # Atuin: Magical Shell History (https://atuin.sh)
+{{ if eq .chezmoi.os "darwin" -}}
 if [[ -d $HOME/.atuin/bin ]] then
   # Add atuin to the path, and init shell plugin
   . "$HOME/.atuin/bin/env"
   eval "$(atuin init zsh)"
   eval "$(atuin gen-completions --shell zsh)"
 fi
+{{- else -}}
+if [[ $(command -v atuin) ]] then
+  eval "$(atuin init zsh)"
+  eval "$(atuin gen-completions --shell zsh)"
+fi
+{{- end }}
 
 # Antidote: the cure to slow zsh plugin management (https://antidote.sh)
 source $(brew --prefix)/opt/antidote/share/antidote/antidote.zsh &>/dev/null && antidote load
@@ -109,20 +116,28 @@ then
   eval "$(direnv hook zsh)"
 fi
 
+{{ if eq .chezmoi.os "darwin" -}}
 # The following lines have been added by Docker Desktop to enable Docker CLI completions.
 fpath=(/Users/aj.alon/.docker/completions $fpath)
 # End of Docker CLI completions
 
 # Added by dr completion installer
 fpath=(/Users/aj.alon/.zsh/completions $fpath)
+{{- end }}
 
 # Added by n-install (see http://git.io/n-install-repo).
 export N_PREFIX="$HOME/n"; [[ :$PATH: == *":$N_PREFIX/bin:"* ]] || PATH+=":$N_PREFIX/bin"
 
 # Added by Factory Desktop
+{{ if eq .chezmoi.os "darwin" -}}
 if [[ -d "/Applications/Factory.app" ]] then
   export PATH="$HOME/.local/bin:$PATH"
 fi
+{{- else -}}
+if [[ $(command -v factory) ]] then
+  export PATH="$HOME/.local/bin:$PATH"
+fi
+{{- end }}
 
 # Added by Cargo
 if [[ -d "$HOME/.cargo/bin" ]] then

--- a/private_dot_config/rstudio/rstudio-prefs.json.tmpl
+++ b/private_dot_config/rstudio/rstudio-prefs.json.tmpl
@@ -20,7 +20,7 @@
   "show_last_dot_value": true,
   "code_formatter": "styler",
   "python_type": "system",
-  "python_version": "3.13.3",
-  "python_path": "/opt/homebrew/bin/python3",
+  "python_version": "{{ if eq .chezmoi.os "darwin" }}3.13.3{{ else }}3.14.6{{ end }}",
+  "python_path": "{{ if eq .chezmoi.os "darwin" }}/opt/homebrew/bin/python3{{ else }}/home/linuxbrew/.linuxbrew/bin/python3{{ end }}",
   "show_terminal_tab": false
 }

--- a/private_dot_config/starship.toml.tmpl
+++ b/private_dot_config/starship.toml.tmpl
@@ -91,7 +91,7 @@ style = "bold yellow"
 command = "yq '.endpoint' ~/.config/datarobot/drconfig.yaml | awk -F'/api/v2' '{print $1}' | awk -F'//' '{print $2}' | sed 's/datarobot.com/dr/g'"
 format = "👾 $output"
 description = "The contents of drconfig.yaml"
-shell = ["dash", "-eu"]
+shell = ["{{ if eq .chezmoi.os `darwin` }}dash{{ else }}sh{{ end }}", "-eu"]
 when = "test -e ~/.config/datarobot/drconfig.yaml && command -v yq"
 
 [custom.git_scope]
@@ -104,7 +104,7 @@ printf "%s (%s)" \
 description = 'The currently configured Git user.{email,name}'
 format = 'as [$output]($style) '
 style = 'blue bold'
-shell = ["dash", "-e"]
+shell = ["{{ if eq .chezmoi.os `darwin` }}dash{{ else }}sh{{ end }}", "-e"]
 when = 'git rev-parse --is-inside-work-tree'
 
 [cmd_duration]


### PR DESCRIPTION
## Summary

Make these dotfiles apply cleanly on Linux (specifically tested on **Bazzite-DX**) without changing what `chezmoi apply` produces on macOS hosts. Each commit was verified to render **byte-identical** to the corresponding file on `origin/main` when rendered with `.chezmoi.os = "darwin"`.

Closes #15.

## Five commits

1. **`feat(zsh)`** — `dot_zshrc.tmpl`
   - `alias edit`: `open` on macOS, `xdg-open` on Linux
   - The `/Users/<user>/...` Docker Desktop and DR-installed completion `fpath` lines are now darwin-only (their inline `compinit` calls were already moved up by #51)
   - `/Applications/Factory.app` check: darwin-only; Linux falls back to `command -v factory`
   - Atuin init: darwin keeps the existing `~/.atuin/bin` curl-install path; Linux uses `command -v atuin` so brew-installed atuin inits correctly

2. **`refactor(profile)`** — `dot_profile` → `dot_profile.tmpl`
   - The macOS-only `~/.atuin/bin/env` and `~/.local/bin/env` source lines are darwin-only
   - On Linux, an explicit `eval "$(brew shellenv)"` block is added so Homebrew/Linuxbrew bins are on `PATH` at login. Without this, fresh shells can't find `chezmoi`, `antidote`, `starship`, `thefuck`, `direnv`, `uv`, etc.

3. **`refactor(rstudio)`** — `rstudio-prefs.json` → `rstudio-prefs.json.tmpl`
   - `python_path` templated per OS
   - `python_version` templated per OS

4. **`refactor(starship)`** — `private_dot_config/starship.toml` → `.toml.tmpl`
   - The two `shell = ["dash", ...]` calls template to `dash` on darwin (unchanged) and POSIX `sh` on Linux (since `dash` is not standard on Fedora)

5. **`feat(git)`** — `dot_gitconfig.tmpl`
   - Added an `else` branch to the `[credential]` block; on non-darwin it sets `helper = store` (the previous version rendered an empty credential block on Linux)

## Test environment

| Item | Value |
|---|---|
| Host OS | Bazzite 44 (Fedora Silverblue / rpm-ostree) |
| Shell used | `zsh` 5.9 (pre-installed at `/usr/bin/zsh`) |
| Homebrew | Linuxbrew at `/home/linuxbrew/.linuxbrew` |
| chezmoi config answered | `dr=false`, `iterm2=false` |

### Functional verify on this Linux host

- `chezmoi status` clean after `chezmoi apply --force`
- Antidote cloned all 10 plugins into `~/.cache/antidote/github.com/`
- Starship prompt renders correctly
- All aliases (`g`, `k`, `t`, `ll`, `cm`, `edit`, `st`) work
- `git wstatus` script runs cleanly
- `(eval):4083: command not found: compdef` warning from my first test is gone after the rebase — already addressed by #51

## Out of scope (left for follow-ups)

- **`chsh` is not shipped on Bazzite,** and linuxbrew's `util-linux` formula surprisingly omits it. Manual alternative: `sudo usermod -s /usr/bin/zsh $USER`. Not addressed in this PR.
- **`pip.conf` and `dot_Rprofile`** corporate-artifactory hostnames are already templated by #52. This PR doesn't double-touch them.
- **Pre-existing latent `.chezmoiignore` issue:** the rule `dot_claude/skills/tech-debt-epic` (in `# if-not-dr` block) doesn't actually exclude the file on `dr=false`. Likely a glob-formulation issue not introduced by this PR.

## Rebase context

This branch was originally pushed against `eb5cbc1` (pre-#50 tip). While testing on Bazzite, `origin/main` moved forward via #50, #51, #52. The branch was rebased + force-pushed onto the current tip (`512fb29`). Only one conflict, in `dot_zshrc.tmpl`: the resolution accepts main's view (which drops the inline `autoload -U compinit && compinit` line that #51 had already removed) and keeps the `{{ if eq .chezmoi.os "darwin" }}…{{ end }}` gate wrapping just the two `fpath=…` lines that still exist on main.