### PR TITLE
feat(bash): init starship and consolidate interactive config into dot_bashrc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 
 # local audit notes
 UNLICENSE-AUDIT.md
+# Bazzite test session — local notes, never committed
+NOTES-bazzite.md

--- a/dot_bash_profile.tmpl
+++ b/dot_bash_profile.tmpl
@@ -1,34 +1,7 @@
-alias ll='ls -al'
-
-# Z
-# TODO How did you install Z?
-. /usr/local/etc/profile.d/z.sh
-
-# Git
-alias g='git'
-
-{{ if .dev.java -}}
-# Maven
-alias mciskip='mvn clean install -DskipTests'
-alias mci='mvn clean install'
-alias mcu='mvn clean install -U'
-alias mvntree='mvn dependency:tree'
-alias mcrun='mvn spring-boot:run -Dspring.profiles.active=LOCAL'
-{{- end }}
-
-# Docker
-alias d='docker'
-alias doco='docker-compose'
-alias docoreup='docker-compose down && docker-compose build && docker-compose up -d'
-
-# Kubernetes
-alias k='kubectl'
-alias kcurrent='kubectl config current-context'
-
-# Terraform
-alias t='terraform'
-
-# install https://github.com/nvbn/thefuck
-eval $(thefuck --alias)
-
-[ -f /usr/local/etc/bash_completion ] && . /usr/local/etc/bash_completion
+# .bash_profile — sourced by login bash shells.
+# All interactive config lives in ~/.bashrc (see dot_bashrc.tmpl).
+# This mirrors the stock /etc/skel/.bash_profile pattern so login shells
+# pick up the same aliases, thefuck, and starship init as non-login shells.
+if [ -f ~/.bashrc ]; then
+    . ~/.bashrc
+fi

--- a/dot_bashrc.tmpl
+++ b/dot_bashrc.tmpl
@@ -1,0 +1,76 @@
+# .bashrc — sourced by interactive non-login bash shells,
+# and by login bash shells via .bash_profile (see dot_bash_profile.tmpl).
+#
+# Mirrors the monolithic dot_zshrc.tmpl approach: one file holds all
+# interactive bash config so login and non-login shells behave identically.
+
+# Source global definitions
+if [ -f /etc/bashrc ]; then
+    . /etc/bashrc
+fi
+
+# User specific environment
+if ! [[ "$PATH" =~ "$HOME/.local/bin:$HOME/bin:" ]]; then
+    PATH="$HOME/.local/bin:$HOME/bin:$PATH"
+fi
+export PATH
+
+# Uncomment the following line if you don't like systemctl's auto-paging feature:
+# export SYSTEMD_PAGER=
+
+# User specific aliases and functions
+if [ -d ~/.bashrc.d ]; then
+    for rc in ~/.bashrc.d/*; do
+        if [ -f "$rc" ]; then
+            . "$rc"
+        fi
+    done
+fi
+unset rc
+
+# LM Studio CLI (lms): only add the flatpak install path to PATH if installed
+if [ -d "$HOME/.var/app/ai.lmstudio.lm-studio/.lmstudio/bin" ]; then
+    export PATH="$PATH:$HOME/.var/app/ai.lmstudio.lm-studio/.lmstudio/bin"
+fi
+
+## Aliases
+alias ll='ls -al'
+alias g='git'
+
+{{ if .dev.java -}}
+# Maven
+alias mciskip='mvn clean install -DskipTests'
+alias mci='mvn clean install'
+alias mcu='mvn clean install -U'
+alias mvntree='mvn dependency:tree'
+alias mcrun='mvn spring-boot:run -Dspring.profiles.active=LOCAL'
+{{- end }}
+
+# Docker
+alias d='docker'
+alias doco='docker-compose'
+alias docoreup='docker-compose down && docker-compose build && docker-compose up -d'
+
+# Kubernetes
+alias k='kubectl'
+alias kcurrent='kubectl config current-context'
+
+# Terraform
+alias t='terraform'
+
+# Z
+# TODO How did you install Z?
+[ -f /usr/local/etc/profile.d/z.sh ] && . /usr/local/etc/profile.d/z.sh
+
+# install https://github.com/nvbn/thefuck
+if command -v thefuck >/dev/null 2>&1; then
+    eval "$(thefuck --alias)"
+fi
+
+# Install https://github.com/scop/bash-completion (Homebrew on macOS)
+[ -f /usr/local/etc/bash_completion ] && . /usr/local/etc/bash_completion
+
+# Starship: Cross-Shell Prompt (https://starship.rs/)
+if command -v starship >/dev/null 2>&1; then
+    eval "$(starship init bash)"
+fi


### PR DESCRIPTION
Closes #54.

## Summary

Starship was only initialized in `dot_zshrc.tmpl`, but on Bazzite DX `$SHELL` is `/bin/bash`, so the prompt never loaded in the default shell. This consolidates all interactive bash config into a new chezmoi-managed `dot_bashrc.tmpl`, slims `dot_bash_profile.tmpl` to sourcing it, and adds `eval "$(starship init bash)"` guarded by `command -v starship`. Mirrors the monolithic `.zshrc` approach.

The first commit resolves the pre-existing `.gitignore` merge conflict as a separately-scoped `chore` commit that recombines the direnv + `UNLICENSE-AUDIT.md` + `NOTES-bazzite.md` "local notes" blocks.

## Changes

### 1. New `dot_bashrc.tmpl` (+76 lines → `~/.bashrc`)

- Preserves the Fedora skeleton: sources `/etc/bashrc`, sets `PATH` (`$HOME/.local/bin:$HOME/bin`), sources `~/.bashrc.d/*` drop-ins.
- LM Studio flatpak PATH block (templatized with `$HOME`, guarded by `[ -d ]`).
- All alias groups moved from `dot_bash_profile.tmpl`:
  - Core: `ll`, `g`
  - Maven (conditional `{{ if .dev.java }}`): `mciskip`, `mci`, `mcu`, `mvntree`, `mcrun`
  - Docker: `d`, `doco`, `docoreup`
  - Kubernetes: `k`, `kcurrent`
  - Terraform: `t`
- Z, thefuck, and bash completion moved over with proper guards (`[ -f ]` for Z, `command -v` for thefuck) — previously unguarded.
- **New:** `eval "$(starship init bash)"` guarded by `command -v starship`, mirroring the zshrc pattern.

### 2. `dot_bash_profile.tmpl` slimmed (-34 lines → `~/.bash_profile`)

Replaced contents with the stock `/etc/skel/.bash_profile` pattern (5 lines): sources `~/.bashrc` so login and non-login interactive bash shells load identical config.

### 3. `private_dot_config/starship.toml.tmpl` — unchanged

Already shell-agnostic. The `[shell]` module's default `bsh` indicator renders in bash.

### 4. `.gitignore` (chore commit) — pre-existing merge conflict resolved

Three local-notes blocks combined: direnv (HEAD) + `UNLICENSE-AUDIT.md` (merge base) + `NOTES-bazzite.md` (theirs).

## Validation

- `chezmoi execute-template` renders both templates without errors
- `bash -n` parses both rendered files (no syntax errors)
- Sourcing the rendered `.bashrc` defines all 5 main aliases (`ll`, `g`, `k`, `d`, `t`) and the starship bash init
- `starship print-config` returns the full 28 KB parsed config (exit 0)
- Login-shell routing simulation confirms `.bash_profile` → `.bashrc` chains correctly

## Out-of-scope follow-up

Tracked separately in **#55**: linuxbrew PATH (`eval $(/home/linuxbrew/.linuxbrew/bin/brew shellenv)`) and LM Studio native install path (`$HOME/.lmstudio/bin`) live in `dot_profile.tmpl`, which bash login shells do not read (because `.bash_profile` exists). On Linux this means `bash -l` and SSH login sessions miss linuxbrew's `bin`/`sbin` on PATH. Could be addressed by sourcing `.profile` from `.bash_profile`, or by extracting linuxbrew into a shared sourced file.

## Test plan

- [x] Apply chezmoi: `chezmoi apply --dry-run` then `chezmoi apply`
- [x] Login shell: `bash -l -c 'alias ll'` returns `alias ll='ls -al'`
- [ ] Non-login shell: open a new terminal, verify starship prompt and aliases
- [ ] zsh: open a new shell, verify prompt and aliases unchanged