### PR TITLE
feat(zsh): drop broken gretzky/n.zsh plugin, source conditionally on n

### DIFF
--- a/dot_zsh_plugins.txt
+++ b/dot_zsh_plugins.txt
@@ -30,4 +30,8 @@ givensuman/zsh-allclear
 matthiasha/zsh-uv-env kind:defer
 
 # auto-switch node.
-gretzky/n.zsh kind:defer
+# gretky/n.zsh kind:defer
+# Disabled 2026-08-08: upstream's switch_n chpwd hook calls `exit 1` when
+# `n` isn't installed, which kills the shell on every cd.
+# Loaded conditionally from ~/.zshrc (grep for "n.zsh conditional") so we
+# can swap in a fork when needed.

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -82,6 +82,17 @@ fi
 # Antidote: the cure to slow zsh plugin management (https://antidote.sh)
 source $(brew --prefix)/opt/antidote/share/antidote/antidote.zsh &>/dev/null && antidote load
 
+# n.zsh plugin -- auto-switch node version when package.json declares one.
+# Disabled upstream because its switch_n chpwd hook calls `exit 1` when
+# `n` isn't installed, which kills the shell on every cd. Removed the
+# antidote entry from .zsh_plugins.txt; now source it conditionally here,
+# gated by `command -v n`. When you fork it, drop the patched file at
+# `~/.local/share/zsh-n-fork/n.plugin.zsh` (or wherever you prefer) and
+# swap the path on the next line.
+if command -v n >/dev/null 2>&1; then
+  zsh-defer source "$HOME/.cache/antidote/github.com/gretzky/n.zsh/n.plugin.zsh"
+fi
+
 # Starship: Cross-Shell Prompt (https://starship.rs/)
 if [[ $(command -v starship) ]] then
   # You may still need to add this at the end of .zshrc for it to work


### PR DESCRIPTION
The upstream gretzky/n.zsh chpwd hook calls `exit 1` when the `n` Node version manager is not installed, which kills zsh on every cd. With Ptyxis 50.1's default exit-action=close, the dying shell closes the only tab, the window has no content, and the Ptyxis process quits -- visible as a string of short-lived ptyxis-spawn-*.scope entries in `journalctl --user` and in the UI as "every cd closes the terminal".

* Comment gretky/n.zsh out of .zsh_plugins.txt.
* Move the source line into dot_zshrc.tmpl, gated by `command -v n` so loading is a safe no-op when `n` is missing.
* The clone under ~/.cache stays on disk so the conditional source can be swapped to a fork pointer when one is published.