### PR TITLE
fix(ci): simplify jq in-flight filter in droid-issue-fixer

### DIFF
--- a/.github/workflows/droid-issue-fixer.yml
+++ b/.github/workflows/droid-issue-fixer.yml
@@ -68,24 +68,35 @@ jobs:
 
           # Open PRs whose head branch starts with droid/issue-.
           gh pr list --state open --json number,headRefName \
-            --jq '[.[] | select(.headRefName | startswith("droid/issue-"))]' \
-            > /tmp/droid-prs.json || echo '[]' > /tmp/droid-prs.json
+            --jq '[.[] | select(.headRefName | startswith("droid/issue-")) | .headRefName]' \
+            > /tmp/droid-pr-branches.json || echo '[]' > /tmp/droid-pr-branches.json
 
-          # Filter out issues that already have an in-flight droid branch.
-          # Match by issue number embedded in the branch name (droid/issue-<N>).
+          # Combine branches + PR head branches into one array, then extract
+          # the issue number from each (droid/issue-<N>...) and dedupe.
+          # This gives us the set of issue numbers that already have an
+          # in-flight droid attempt.
+          jq -n \
+            --slurpfile branches /tmp/droid-branches.json \
+            --slurpfile prs /tmp/droid-pr-branches.json \
+            '($branches[0] + $prs[0])
+              | map(capture("issue-(?<n>[0-9]+)") | .n | tonumber)
+              | unique' > /tmp/inflight-nums.json
+
+          echo "In-flight droid issue numbers: $(cat /tmp/inflight-nums.json)"
+
+          # Filter open issues: keep those whose number is NOT in the
+          # in-flight set. Also build the inflight metadata for the prompt.
           jq -n \
             --slurpfile issues /tmp/open-issues.json \
+            --slurpfile inflight /tmp/inflight-nums.json \
             --slurpfile branches /tmp/droid-branches.json \
-            --slurpfile prs /tmp/droid-prs.json \
+            --slurpfile prs /tmp/droid-pr-branches.json \
             '{
-              issues: ($issues[0]
-                | map(. as $iss
-                  | ($branches[0] + $prs[0].headRefName)
-                    | any(. as $b | $b | test("issue-" + ($iss.number | tostring) + "[-/]")))
-                  | select(not)) ),
+              issues: ($issues[0] | map(select(.number as $n | $inflight[0] | index($n) | not))),
               inflight: {
+                issue_numbers: $inflight[0],
                 branches: $branches[0],
-                prs: [$prs[0][].headRefName]
+                pr_branches: $prs[0]
               }
             }' > /tmp/actionable.json
 


### PR DESCRIPTION
## Summary

Fixes a jq compile error in the `droid-issue-fixer` workflow that prevented it from running on the first manual trigger.

### Error

```
jq: error: syntax error, unexpected INVALID_CHARACTER, expecting '}' (Unix shell quoting issues?) at <top-level>, line 6:
        | select(not)) ),
jq: 1 compile error
```

### Root cause

The original jq one-liner used a complex `any()` / `test()` chain with nested variable bindings (`$iss`, `$b`) and regex matching inside a `map(... | select(not))` pipeline. The jq parser choked on it.

### Fix

Replaced with a simpler two-step approach:
1. Extract issue numbers from `droid/issue-*` branch names into a flat, deduplicated array.
2. Filter open issues with a simple `index()` lookup against that array.

Verified the logic locally with mock data (3 issues, 2 in-flight branches) — correctly filters in-flight issues and passes through the rest.
