### PR TITLE
fix(ci): only quiet-skip on auth/quota when droid exec actually failed

### DIFF
--- a/.github/workflows/droid-issue-fixer.yml
+++ b/.github/workflows/droid-issue-fixer.yml
@@ -214,26 +214,33 @@ jobs:
           set -euo pipefail
           droid_exit="${{ steps.droid.outputs.droid_exit }}"
 
-          # Extract the result text from JSON output for signature matching.
+          # Extract the result text and is_error flag from JSON output.
           result_text=""
+          is_error="false"
           if [ -f /tmp/droid-out.json ]; then
             result_text=$(jq -r '.result // ""' /tmp/droid-out.json 2>/dev/null || echo "")
+            is_error=$(jq -r '.is_error // false' /tmp/droid-out.json 2>/dev/null || echo "false")
           fi
 
-          # Auth/quota/billing signatures → quiet green exit.
-          quiet_signatures='Authentication failed|FACTORY_API_KEY|insufficient|quota|credit|limit exceeded|402|403|429|billing|plan limit'
-          if echo "$result_text" | grep -iqE "$quiet_signatures"; then
-            echo "::warning::Droid exec hit an auth/quota/billing limit — skipping quietly."
-            {
-              echo "## Droid Issue Fixer — quiet skip"
-              echo ""
-              echo "Droid exec returned a quota/auth/billing error and was skipped quietly."
-              echo ""
-              echo "**Result:** $result_text"
-            } >> "$GITHUB_STEP_SUMMARY"
-            echo "quiet_skip=true" >> "$GITHUB_OUTPUT"
-            echo "hard_fail=false" >> "$GITHUB_OUTPUT"
-            exit 0
+          # Auth/quota/billing quiet skip: only when droid exec actually
+          # failed (non-zero exit or is_error=true). A successful run may
+          # mention "FACTORY_API_KEY" or "credit" in its output without
+          # being an auth failure.
+          if [ "$droid_exit" -ne 0 ] || [ "$is_error" = "true" ]; then
+            quiet_signatures='Authentication failed|invalid.*key|insufficient|quota|limit exceeded|402|403|429|billing|plan limit|rate limit'
+            if echo "$result_text" | grep -iqE "$quiet_signatures"; then
+              echo "::warning::Droid exec hit an auth/quota/billing limit — skipping quietly."
+              {
+                echo "## Droid Issue Fixer — quiet skip"
+                echo ""
+                echo "Droid exec returned a quota/auth/billing error and was skipped quietly."
+                echo ""
+                echo "**Result:** $result_text"
+              } >> "$GITHUB_STEP_SUMMARY"
+              echo "quiet_skip=true" >> "$GITHUB_OUTPUT"
+              echo "hard_fail=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
           fi
 
           echo "quiet_skip=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Fixes a false positive in the quiet-skip classifier that prevented a successful droid run from pushing its branch and opening a PR.

### What happened

The droid successfully picked issue #69, created branch `droid/issue-69-home-paths`, committed the fix, and validated it. But the classifier matched `FACTORY_API_KEY` and `credit` in the droid's *success* output (it mentioned the env var name and the JSON included `factory_credits` in usage stats), triggering a false quiet-skip that discarded the work.

### Fix

- Only check auth/quota signatures when `droid_exit` is non-zero **or** `is_error` is `true` in the JSON output.
- Tightened signatures: removed bare `FACTORY_API_KEY` and `credit` (too broad for success output), added `rate limit` and `invalid.*key`.

### Test plan

Re-trigger the workflow after merge. The droid should pick another issue (likely #69 again or #70/#71), and this time the push + PR creation steps should run.
