### PR TITLE
[81] droid.sh now compatible with bash 3.2

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -10,6 +10,15 @@
 
 {{- $scratchpadDir := promptStringOnce . "scratchpad" "In which folder does your scratchpad live?" }}
 
+# Probe the major version of the bash found in PATH (macOS ships 3.2,
+# Fedora 4.0+). 0 means bash is absent, which .chezmoiignore treats as
+# "oldest supported" so the most conservative file variant is deployed.
+# This runs only at `chezmoi init` time; the result is persisted below.
+{{ $bashMajor := 0 -}}
+{{ if lookPath "bash" -}}
+{{ $bashMajor = output "bash" "-c" "echo ${BASH_VERSINFO[0]}" | trim | int -}}
+{{ end -}}
+
 [data]
 email = {{ $email | quote }}
 dr = {{ $isDRDevMachine }}
@@ -17,6 +26,10 @@ iterm2 = {{ $isIterm2Managed }}
 artifactoryHost = {{ $artifactoryHost | quote }}
 # what folder is your scratchpad?
 scratchpad = {{ $scratchpadDir | quote }}
+# major version of the bash in PATH at `chezmoi init` time (issue #81);
+# .chezmoiignore uses this to pick bash-version-specific files.
+# re-run `chezmoi init` to refresh after upgrading bash.
+bashMajor = {{ $bashMajor }}
 
 [data.dev]
 java = {{ $isJavaDev }}

--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -30,7 +30,8 @@ Library/Preferences/com.googlecode.iterm2.plist
 {{- end }}
 
 # Ignore work files.
+# Patterns match target paths, not source paths (hence .claude, not dot_claude).
 {{- if not .dr }}
 workspace/DataRobot
-dot_claude/skills/tech-debt-epic
+.claude/skills/tech-debt-epic
 {{- end }}

--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -35,3 +35,16 @@ Library/Preferences/com.googlecode.iterm2.plist
 workspace/DataRobot
 .claude/skills/tech-debt-epic
 {{- end }}
+
+# bash-version-specific droid wrapper (issue #81): deploy only the variant
+# matching this host's bash major version. Patterns match target paths, so
+# .shellrc.d here, not dot_shellrc.d.
+# `get`+`default` keeps `chezmoi apply` working on hosts whose chezmoi.toml
+# predates the bashMajor key; they get the bash 3.2 (most conservative)
+# variant until `chezmoi init` repopulates the config.
+{{ $bashMajor := get . "bashMajor" | default 0 | int -}}
+{{ if ge $bashMajor 4 -}}
+.shellrc.d/10-droid-bash3.sh
+{{- else -}}
+.shellrc.d/10-droid-bash4.sh
+{{- end }}

--- a/README.md
+++ b/README.md
@@ -15,6 +15,21 @@
 - bash 3.2 (required for MacOS Sonoma)
 - bash 4.0 (Fedora)
 
+### bash-version-specific files (issue #81)
+
+Some snippets require bash 4.0+ features (e.g. associative arrays in the
+`droid` wrapper), while macOS ships bash 3.2. Rather than branching inside
+Go templates, chezmoi deploys entirely different files per bash version:
+
+- `.chezmoi.toml.tmpl` probes the bash in `PATH` at `chezmoi init` time and
+  persists its major version as `data.bashMajor` (0 if bash is absent).
+- `.chezmoiignore` reads `bashMajor` and deploys exactly one of
+  `~/.shellrc.d/10-droid-bash3.sh` (bash < 4.0) or
+  `~/.shellrc.d/10-droid-bash4.sh` (bash >= 4.0).
+
+After upgrading bash on a host, re-run `chezmoi init` to refresh
+`bashMajor`, then `chezmoi apply`.
+
 ## Prerequisites
 
 ### Required

--- a/dot_shellrc.d/private_10-droid-bash3.sh.tmpl
+++ b/dot_shellrc.d/private_10-droid-bash3.sh.tmpl
@@ -1,9 +1,37 @@
-# ~/.bashrc.d/droid.sh
+# ~/.shellrc.d/10-droid-bash3.sh — bash 3.2 variant of the droid wrapper.
+#
+# Deployed by chezmoi only on hosts whose bash predates 4.0 (e.g. macOS,
+# which ships /bin/bash 3.2); the bash 4.0+ sibling 10-droid-bash4.sh is
+# deployed elsewhere. Selection is driven by data.bashMajor (set at
+# `chezmoi init` time) via .chezmoiignore; see issue #81.
+#
+# bash 3.2 lacks associative arrays, so trusted folders are kept as a
+# newline-delimited list with a linear membership scan (the list is tiny).
+# This file is also sourced by zsh on macOS (via the ~/.shellrc.d loop in
+# ~/.zshrc), so it avoids two zsh pitfalls as well:
+#   - no `for x in $unquoted_list` iteration (zsh does not word-split
+#     unquoted variables, so such loops see the whole string at once)
+#   - locals are declared once, outside loops (redeclaring an existing
+#     local makes zsh's typeset print "name=value" on every iteration)
+#
 # Smart droid wrapper: redirects to nearest trusted folder (or ~/scratch),
 # unless running a subcommand or an explicit --cwd is given.
 
 # Known subcommands that should NOT be redirected (always run in CWD)
 _droid_subcommands="exec daemon search find update mcp plugin computer help"
+
+# _droid_trusted_contains NEEDLE LIST — return 0 if NEEDLE is one of the
+# newline-delimited entries of LIST. Whole-string comparison, so there are
+# no associative-array subscript quoting differences between bash and zsh.
+_droid_trusted_contains() {
+    local needle=$1
+    local list=$2
+    local line
+    while IFS= read -r line; do
+        [[ "$line" == "$needle" ]] && return 0
+    done <<< "$list"
+    return 1
+}
 
 _droid_smart() {
     # 1. If user explicitly passed --cwd, pass through untouched
@@ -35,15 +63,16 @@ _droid_smart() {
             ;;
     esac
 
-    # 3. Read trusted folders from settings.json (canonical paths via realpath)
-    declare -A _trusted=()
+    # 3. Read trusted folders from settings.json into a newline-delimited
+    # list (canonical paths via realpath when available; stock macOS lacks
+    # realpath, in which case paths are compared as written).
+    local t rt
+    local trusted_list=""
     if [[ -f "$HOME/.factory/settings.json" ]]; then
-        local t
         while IFS= read -r t; do
             [[ -z "$t" ]] && continue
-            local rt
             rt=$(realpath "$t" 2>/dev/null || echo "$t")
-            _trusted["$rt"]=1
+            trusted_list="${trusted_list}${rt}"$'\n'
         done < <(jq -r '.trustedFolders | keys[]?' "$HOME/.factory/settings.json" 2>/dev/null)
     fi
 
@@ -52,7 +81,7 @@ _droid_smart() {
     local dir
     dir=$(realpath "$PWD" 2>/dev/null || echo "$PWD")
     while [[ -n "$dir" && "$dir" != "/" ]]; do
-        if [[ -n "${_trusted[$dir]+x}" ]]; then
+        if _droid_trusted_contains "$dir" "$trusted_list"; then
             target="$dir"
             break
         fi
@@ -63,6 +92,9 @@ _droid_smart() {
     # Fallback path comes from chezmoi data (chezmoi.toml -> data.scratchpad).
     if [[ -z "$target" ]]; then
         target={{ .scratchpad | quote }}
+        # A leading ~ does not expand inside quotes; expand it explicitly
+        # so hosts without realpath don't pass a literal "~" to droid.
+        target="${target/#\~/$HOME}"
         target=$(realpath "$target" 2>/dev/null || echo "$target")
     fi
 

--- a/dot_shellrc.d/private_10-droid-bash4.sh.tmpl
+++ b/dot_shellrc.d/private_10-droid-bash4.sh.tmpl
@@ -1,0 +1,81 @@
+# ~/.shellrc.d/10-droid-bash4.sh — bash 4.0+ variant of the droid wrapper.
+#
+# Deployed by chezmoi only on hosts whose bash is 4.0 or newer (e.g.
+# Fedora); the bash 3.2-compatible sibling 10-droid-bash3.sh is deployed
+# elsewhere (e.g. macOS). Selection is driven by data.bashMajor (set at
+# `chezmoi init` time) via .chezmoiignore; see issue #81. This variant
+# uses associative arrays (declare -A), which bash 3.2 lacks.
+#
+# Smart droid wrapper: redirects to nearest trusted folder (or ~/scratch),
+# unless running a subcommand or an explicit --cwd is given.
+
+# Known subcommands that should NOT be redirected (always run in CWD)
+_droid_subcommands="exec daemon search find update mcp plugin computer help"
+
+_droid_smart() {
+    # 1. If user explicitly passed --cwd, pass through untouched
+    local arg
+    for arg in "$@"; do
+        if [[ "$arg" == "--cwd" || "$arg" == --cwd=* ]]; then
+            command droid "$@"
+            return $?
+        fi
+    done
+
+    # 2. If first positional arg is a subcommand, pass through (no redirect)
+    local first_positional=""
+    for arg in "$@"; do
+        if [[ "$arg" != -* ]]; then
+            first_positional="$arg"
+            break
+        fi
+    done
+    # Word-list membership via case: portable across bash 3.2, bash 4+,
+    # and zsh. zsh does not word-split unquoted variables, so the naive
+    # `for sub in $_droid_subcommands` compares the whole string once and
+    # never matches. Quoted expansion in the pattern stays literal, so a
+    # first_positional containing glob characters cannot false-match.
+    case " $_droid_subcommands " in
+        *" $first_positional "*)
+            command droid "$@"
+            return $?
+            ;;
+    esac
+
+    # 3. Read trusted folders from settings.json (canonical paths via realpath)
+    declare -A _trusted=()
+    if [[ -f "$HOME/.factory/settings.json" ]]; then
+        local t
+        while IFS= read -r t; do
+            [[ -z "$t" ]] && continue
+            local rt
+            rt=$(realpath "$t" 2>/dev/null || echo "$t")
+            _trusted["$rt"]=1
+        done < <(jq -r '.trustedFolders | keys[]?' "$HOME/.factory/settings.json" 2>/dev/null)
+    fi
+
+    # 4. Walk up from PWD to find nearest trusted ancestor
+    local target=""
+    local dir
+    dir=$(realpath "$PWD" 2>/dev/null || echo "$PWD")
+    while [[ -n "$dir" && "$dir" != "/" ]]; do
+        if [[ -n "${_trusted[$dir]+x}" ]]; then
+            target="$dir"
+            break
+        fi
+        dir=$(dirname "$dir")
+    done
+
+    # 5. No trusted ancestor → default to scratchpad
+    # Fallback path comes from chezmoi data (chezmoi.toml -> data.scratchpad).
+    if [[ -z "$target" ]]; then
+        target={{ .scratchpad | quote }}
+        target=$(realpath "$target" 2>/dev/null || echo "$target")
+    fi
+
+    command droid --cwd "$target" "$@"
+}
+
+droid()      { _droid_smart "$@"; }
+dr()         { _droid_smart "$@"; }
+droid-here() { command droid "$@"; }

--- a/dot_shellrc.d/private_10-droid.sh.tmpl
+++ b/dot_shellrc.d/private_10-droid.sh.tmpl
@@ -23,13 +23,17 @@ _droid_smart() {
             break
         fi
     done
-    local sub
-    for sub in $_droid_subcommands; do
-        if [[ "$first_positional" == "$sub" ]]; then
+    # Word-list membership via case: portable across bash 3.2, bash 4+,
+    # and zsh. zsh does not word-split unquoted variables, so the naive
+    # `for sub in $_droid_subcommands` compares the whole string once and
+    # never matches. Quoted expansion in the pattern stays literal, so a
+    # first_positional containing glob characters cannot false-match.
+    case " $_droid_subcommands " in
+        *" $first_positional "*)
             command droid "$@"
             return $?
-        fi
-    done
+            ;;
+    esac
 
     # 3. Read trusted folders from settings.json (canonical paths via realpath)
     declare -A _trusted=()


### PR DESCRIPTION
- move 10-droid.sh to 10-droid-bash4.sh because it uses associative arrays
- refactor 10-droid.sh to 10-droid-bash3.sh to be bash 3.2 and zsh compatible
- chezmoi data now stores bashMajor version
- use chezmoiignore template blocks to load

Closes #81 