### PR TITLE
[81] use SCRATCHPAD env var

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -8,8 +8,6 @@
 {{- $artifactoryHost = promptStringOnce . "artifactoryHost" "DataRobot Artifactory hostname" }}
 {{- end }}
 
-{{- $scratchpadDir := promptStringOnce . "scratchpad" "In which folder does your scratchpad live?" }}
-
 # Probe the major version of the bash found in PATH (macOS ships 3.2,
 # Fedora 4.0+). 0 means bash is absent, which .chezmoiignore treats as
 # "oldest supported" so the most conservative file variant is deployed.
@@ -24,8 +22,6 @@ email = {{ $email | quote }}
 dr = {{ $isDRDevMachine }}
 iterm2 = {{ $isIterm2Managed }}
 artifactoryHost = {{ $artifactoryHost | quote }}
-# what folder is your scratchpad?
-scratchpad = {{ $scratchpadDir | quote }}
 # major version of the bash in PATH at `chezmoi init` time (issue #81);
 # .chezmoiignore uses this to pick bash-version-specific files.
 # re-run `chezmoi init` to refresh after upgrading bash.

--- a/.github/workflows/droid-issue-fixer.yml
+++ b/.github/workflows/droid-issue-fixer.yml
@@ -147,7 +147,6 @@ jobs:
             'dr = false' \
             'iterm2 = false' \
             'artifactoryHost = ""' \
-            'scratchpad = "/tmp/scratchpad"' \
             '[data.dev]' \
             'java = false' \
             '[data.fonts]' \

--- a/dot_shellrc.d/01-env.sh
+++ b/dot_shellrc.d/01-env.sh
@@ -1,7 +1,6 @@
 # 01-env.sh — shared environment variables for bash and zsh.
 # Sourced on every interactive shell startup via the ~/.shellrc.d/ loops
-# in dot_bashrc.tmpl and dot_zshrc.tmpl. Keep this file POSIX-compatible:
-# macOS ships bash 3.2, so no arrays, no zsh-isms.
+# in dot_bashrc.tmpl and dot_zshrc.tmpl. Keep this file POSIX-compatible.
 
 # Root of the user's workspace tree (projects, scratchpads, etc.).
 export WORKSPACE="${HOME}/workspace"

--- a/dot_shellrc.d/01-env.sh
+++ b/dot_shellrc.d/01-env.sh
@@ -1,7 +1,13 @@
-# 10-env.sh — shared environment variables for bash and zsh.
+# 01-env.sh — shared environment variables for bash and zsh.
 # Sourced on every interactive shell startup via the ~/.shellrc.d/ loops
 # in dot_bashrc.tmpl and dot_zshrc.tmpl. Keep this file POSIX-compatible:
 # macOS ships bash 3.2, so no arrays, no zsh-isms.
 
 # Root of the user's workspace tree (projects, scratchpads, etc.).
 export WORKSPACE="${HOME}/workspace"
+
+# General-purpose scratch directory (throwaway repos, experiments, notes).
+# Consumed by the droid wrapper (10-droid-bash*.sh) as its default cwd,
+# but intentionally not droid-specific. The :- guard lets a machine
+# override it earlier (e.g. ~/.profile); always use an absolute path.
+export SCRATCHPAD="${SCRATCHPAD:-${WORKSPACE}/scratch}"

--- a/dot_shellrc.d/01-env.sh
+++ b/dot_shellrc.d/01-env.sh
@@ -9,4 +9,4 @@ export WORKSPACE="${HOME}/workspace"
 # Consumed by the droid wrapper (10-droid-bash*.sh) as its default cwd,
 # but intentionally not droid-specific. The :- guard lets a machine
 # override it earlier (e.g. ~/.profile); always use an absolute path.
-export SCRATCHPAD="${SCRATCHPAD:-${WORKSPACE}/scratch}"
+export SCRATCHPAD="${SCRATCHPAD:-${HOME}/scratch}"

--- a/dot_shellrc.d/private_10-droid-bash3.sh
+++ b/dot_shellrc.d/private_10-droid-bash3.sh
@@ -90,10 +90,10 @@ _droid_smart() {
 
     # 5. No trusted ancestor → default to the scratchpad.
     # SCRATCHPAD is exported by ~/.shellrc.d/01-env.sh (default:
-    # $WORKSPACE/scratch); the inline fallback keeps this file sane even
+    # $HOME/scratch); the inline fallback keeps this file sane even
     # if it is ever sourced without 01-env.sh.
     if [[ -z "$target" ]]; then
-        target=${SCRATCHPAD:-$HOME/workspace/scratch}
+        target=${SCRATCHPAD:-$HOME/scratch}
     fi
 
     command droid --cwd "$target" "$@"

--- a/dot_shellrc.d/private_10-droid-bash3.sh
+++ b/dot_shellrc.d/private_10-droid-bash3.sh
@@ -14,7 +14,7 @@
 #   - locals are declared once, outside loops (redeclaring an existing
 #     local makes zsh's typeset print "name=value" on every iteration)
 #
-# Smart droid wrapper: redirects to nearest trusted folder (or ~/scratch),
+# Smart droid wrapper: redirects to nearest trusted folder (or $SCRATCHPAD),
 # unless running a subcommand or an explicit --cwd is given.
 
 # Known subcommands that should NOT be redirected (always run in CWD)
@@ -88,14 +88,12 @@ _droid_smart() {
         dir=$(dirname "$dir")
     done
 
-    # 5. No trusted ancestor → default to scratchpad
-    # Fallback path comes from chezmoi data (chezmoi.toml -> data.scratchpad).
+    # 5. No trusted ancestor → default to the scratchpad.
+    # SCRATCHPAD is exported by ~/.shellrc.d/01-env.sh (default:
+    # $WORKSPACE/scratch); the inline fallback keeps this file sane even
+    # if it is ever sourced without 01-env.sh.
     if [[ -z "$target" ]]; then
-        target={{ .scratchpad | quote }}
-        # A leading ~ does not expand inside quotes; expand it explicitly
-        # so hosts without realpath don't pass a literal "~" to droid.
-        target="${target/#\~/$HOME}"
-        target=$(realpath "$target" 2>/dev/null || echo "$target")
+        target=${SCRATCHPAD:-$HOME/workspace/scratch}
     fi
 
     command droid --cwd "$target" "$@"

--- a/dot_shellrc.d/private_10-droid-bash4.sh
+++ b/dot_shellrc.d/private_10-droid-bash4.sh
@@ -68,10 +68,10 @@ _droid_smart() {
 
     # 5. No trusted ancestor → default to the scratchpad.
     # SCRATCHPAD is exported by ~/.shellrc.d/01-env.sh (default:
-    # $WORKSPACE/scratch); the inline fallback keeps this file sane even
+    # $HOME/scratch); the inline fallback keeps this file sane even
     # if it is ever sourced without 01-env.sh.
     if [[ -z "$target" ]]; then
-        target=${SCRATCHPAD:-$HOME/workspace/scratch}
+        target=${SCRATCHPAD:-$HOME/scratch}
     fi
 
     command droid --cwd "$target" "$@"

--- a/dot_shellrc.d/private_10-droid-bash4.sh
+++ b/dot_shellrc.d/private_10-droid-bash4.sh
@@ -6,7 +6,7 @@
 # `chezmoi init` time) via .chezmoiignore; see issue #81. This variant
 # uses associative arrays (declare -A), which bash 3.2 lacks.
 #
-# Smart droid wrapper: redirects to nearest trusted folder (or ~/scratch),
+# Smart droid wrapper: redirects to nearest trusted folder (or $SCRATCHPAD),
 # unless running a subcommand or an explicit --cwd is given.
 
 # Known subcommands that should NOT be redirected (always run in CWD)
@@ -66,11 +66,12 @@ _droid_smart() {
         dir=$(dirname "$dir")
     done
 
-    # 5. No trusted ancestor → default to scratchpad
-    # Fallback path comes from chezmoi data (chezmoi.toml -> data.scratchpad).
+    # 5. No trusted ancestor → default to the scratchpad.
+    # SCRATCHPAD is exported by ~/.shellrc.d/01-env.sh (default:
+    # $WORKSPACE/scratch); the inline fallback keeps this file sane even
+    # if it is ever sourced without 01-env.sh.
     if [[ -z "$target" ]]; then
-        target={{ .scratchpad | quote }}
-        target=$(realpath "$target" 2>/dev/null || echo "$target")
+        target=${SCRATCHPAD:-$HOME/workspace/scratch}
     fi
 
     command droid --cwd "$target" "$@"


### PR DESCRIPTION
- use a SCRATCHPAD env var; this simplifies 10-droid.sh a bit
- point to $HOME/scratch by default; I think I want to keep workspace for more engineered projects