### PR TITLE
fix(zsh): vet plugin stack, drop zsh-vi-mode and ez-compinit

### DIFF
--- a/dot_zsh_plugins.txt
+++ b/dot_zsh_plugins.txt
@@ -14,9 +14,6 @@ zdharma-continuum/fast-syntax-highlighting kind:defer
 # frecent directory jumping (z command).
 agkozak/zsh-z
 
-# normal vi mode in ZSH sucks.
-jeffreytse/zsh-vi-mode kind:defer
-
 # replace aliases with abbreviations.
 #olets/zsh-abbr kind:defer
 

--- a/dot_zsh_plugins.txt
+++ b/dot_zsh_plugins.txt
@@ -2,6 +2,8 @@
 
 # This is used by antidote. Do you have it?
 # ref: https://antidote.sh/
+# NOTE: antidote pins clones at first install; run `antidote update`
+# periodically to pull upstream fixes (see #96).
 
 # Basic Zsh plugins are defined in user/repo format
 
@@ -26,6 +28,6 @@ matthiasha/zsh-uv-env kind:defer
 # auto-switch node.
 # gretky/n.zsh kind:defer
 # Disabled 2026-08-08: upstream's switch_n chpwd hook calls `exit 1` when
-# `n` isn't installed, which kills the shell on every cd.
-# Loaded conditionally from ~/.zshrc (grep for "n.zsh conditional") so we
-# can swap in a fork when needed.
+# `n` isn't installed, which kills the shell on every cd. The conditional
+# loader in ~/.zshrc was removed in #88; a local rewrite sits unpublished
+# at ~/workspace/n.zsh.

--- a/dot_zsh_plugins.txt
+++ b/dot_zsh_plugins.txt
@@ -2,8 +2,7 @@
 
 # This is used by antidote. Do you have it?
 # ref: https://antidote.sh/
-# NOTE: antidote pins clones at first install; run `antidote update`
-# periodically to pull upstream fixes (see #96).
+Also, antidote pins everything. Did you update recently?
 
 # Basic Zsh plugins are defined in user/repo format
 

--- a/dot_zsh_plugins.txt
+++ b/dot_zsh_plugins.txt
@@ -14,9 +14,6 @@ zdharma-continuum/fast-syntax-highlighting kind:defer
 # frecent directory jumping (z command).
 agkozak/zsh-z
 
-# faster completion initialization.
-mattmc3/ez-compinit
-
 # normal vi mode in ZSH sucks.
 jeffreytse/zsh-vi-mode kind:defer
 

--- a/dot_zshrc.tmpl
+++ b/dot_zshrc.tmpl
@@ -3,6 +3,22 @@ setopt autocd
 # vim keybindings in shell
 bindkey -v
 
+# Stock vi-mode tweaks (replaces jeffreytse/zsh-vi-mode, which clobbered
+# atuin's ^R when it re-initialized the keymaps on load -- see #95)
+export KEYTIMEOUT=10  # 100ms ESC delay (default 40 = 400ms feels laggy)
+
+# Cursor shape per vi mode: beam in insert, block in normal
+function zle-keymap-select {
+  case $KEYMAP in
+    vicmd) print -n '\e[2 q' ;;
+    viins|main) print -n '\e[6 q' ;;
+  esac
+  zle reset-prompt
+}
+zle -N zle-keymap-select
+function zle-line-init { print -n '\e[6 q' }
+zle -N zle-line-init
+
 ## Env Vars
 # homebrew is great but is actively hostile sometimes
 export HOMEBREW_NO_AUTO_UPDATE=1


### PR DESCRIPTION
## Summary

Plugin-stack vetting from #59 (follow-up to the gretzky/n.zsh shell-killer in #58). Three commits:

- **`fix(zsh): remove redundant ez-compinit plugin`** — `~/.zshrc` already runs real `compinit` early so pre-antidote tools (atuin) can emit `compdef`; ez-compinit then re-ran compinit at the first precmd against a second dumpfile, so every shell paid for compinit twice.
- **`fix(zsh): replace zsh-vi-mode with stock vi mode`** — zvm re-initializes the ZLE keymaps on deferred load, clobbering atuin's `^R` (atuinsh/atuin#1826, jeffreytse/zsh-vi-mode#242). With zero `ZVM_` config in this repo, the advanced features go unused; adds `KEYTIMEOUT=10` and a `zle-keymap-select` cursor-shape hook to keep mode feedback.
- **`docs(zsh): fix stale .zsh_plugins.txt comments`** — the n.zsh comment claimed a conditional loader in `~/.zshrc` that #88 removed (it also used the Linux antidote cache path, so it never worked on macOS); documents that antidote pins clones and needs periodic `antidote update`.

## Validation

- `antidote update` run 2026-08-09 (every clone was 1–3 years stale; the stale zsh-uv-env clone was missing an upstream guard-fix); startup smoke-tested.
- Fresh shell: `run-compinit` gone from `precmd_functions`, main keymap is `viins`, `^R` → `atuin-search-viins`, `compdef` and `z` work, startup ~0.21s (baseline ~0.20s).

Closes #95
Closes #96
Refs #59, #94 — the zsh-z `exit`-in-function fix lives on ahjota/zsh-z@`fix/exit-to-return`, tracked upstream in agkozak/zsh-z#103. Antidote stays pinned to upstream zsh-z unless #103 stalls.
