### PR TITLE
fix(zsh): restore comment marker on antidote note

### DIFF
--- a/dot_zsh_plugins.txt
+++ b/dot_zsh_plugins.txt
@@ -2,7 +2,7 @@
 
 # This is used by antidote. Do you have it?
 # ref: https://antidote.sh/
-Also, antidote pins everything. Did you update recently?
+# Also, antidote pins everything. Did you update recently?
 
 # Basic Zsh plugins are defined in user/repo format
 


### PR DESCRIPTION
The joke comment landed without its `#`, so antidote tried to parse it as a bundle spec — that's the `/dev/fd/14:1: no matches found: --recently?` seen on the first post-merge shell. One-off only because the regenerated static bundle is cached; it would return on the next `.zsh_plugins.txt` change. Keeps the joke, adds the marker.