### PR TITLE
fix(droid-issue-fixer): correct broken cron schedule

### DIFF
--- a/.github/workflows/droid-issue-fixer.yml
+++ b/.github/workflows/droid-issue-fixer.yml
@@ -13,8 +13,10 @@ name: Droid Issue Fixer
 on:
   workflow_dispatch:
   schedule:
-    # Runs Thu-Mon at 9am UTC, with a random minute to avoid cron spikes.
-    - cron: "17-47 9 * * 4-1"
+    # Runs Thu-Mon at 09:17 UTC (off-the-hour to avoid GitHub cron spikes).
+    # Day-of-week: 0=Sun,1=Mon,4=Thu,5=Fri,6=Sat — cron ranges don't wrap, so
+    # Thu-Mon is expressed as the list 0-1,4-6 (not 4-1).
+    - cron: "17 9 * * 0-1,4-6"
 
 permissions:
   contents: write


### PR DESCRIPTION
The previous cron "17-47 9 * * 4-1" had two bugs:

1. Minute range "17-47" fires at every minute from :17 to :47 (31 runs per day), not once at a "random" minute. Cron ranges enumerate all values in the range.

2. Day-of-week "4-1" is invalid — cron DOW ranges don't wrap, so Thu(4)→Mon(1) matches nothing. Thu-Mon must be expressed as the list 0-1,4-6 (Sun, Mon, Thu, Fri, Sat).

Fixed to "17 9 * * 0-1,4-6": once per day at 09:17 UTC, Thu through Mon.