### PR TITLE
feat(ci): soft-fail artifact steps and fix linuxbrew bash login PATH

### DIFF
--- a/.github/workflows/droid-issue-fixer.yml
+++ b/.github/workflows/droid-issue-fixer.yml
@@ -382,6 +382,7 @@ jobs:
       # ------------------------------------------------------------------
       - name: Fetch session messages
         if: steps.collect.outputs.has_work == 'true'
+        continue-on-error: true
         env:
           FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
         run: |
@@ -440,6 +441,7 @@ jobs:
       # ------------------------------------------------------------------
       - name: Upload droid session artifacts
         if: steps.collect.outputs.has_work == 'true'
+        continue-on-error: true
         uses: actions/upload-artifact@v7.0.1
         with:
           name: droid-session-${{ github.run_id }}

--- a/.github/workflows/droid-issue-fixer.yml
+++ b/.github/workflows/droid-issue-fixer.yml
@@ -396,35 +396,41 @@ jobs:
 
           echo "Fetching messages for session $session_id..."
 
-          # Paginate through the session messages API and accumulate all
-          # messages into a single JSON array.
+          # Paginate through the session messages API and write each page to
+          # its own file. Using files instead of command-line arguments
+          # avoids "Argument list too long" errors when sessions have many
+          # messages.
+          pages_dir="$WORKFLOW_TEMP/messages-pages"
+          mkdir -p "$pages_dir"
+          rm -f "$pages_dir"/*.json
+
           cursor=""
-          all_messages="[]"
+          page_num=0
           while true; do
             url="https://api.factory.ai/api/v0/sessions/$session_id/messages?limit=100"
             if [ -n "$cursor" ]; then
               url="${url}&cursor=${cursor}"
             fi
 
-            page_file="$WORKFLOW_TEMP/messages-page.json"
+            page_file="$pages_dir/page-$(printf '%03d' $page_num).json"
             curl -fsSL \
               -H "Authorization: Bearer $FACTORY_API_KEY" \
               "$url" > "$page_file"
-
-            page_messages=$(jq '.messages // []' "$page_file" 2>/dev/null || echo '[]')
-            all_messages=$(jq -n \
-              --argjson all "$all_messages" \
-              --argjson msgs "$page_messages" \
-              '$all + $msgs')
 
             cursor=$(jq -r '.cursor // ""' "$page_file" 2>/dev/null || echo "")
             if [ -z "$cursor" ]; then
               break
             fi
+            page_num=$((page_num + 1))
           done
 
-          jq -n --argjson msgs "$all_messages" '{messages: $msgs}' \
-            > $WORKFLOW_TEMP/droid-messages.json
+          # Combine all pages into a single messages array.
+          if ls "$pages_dir"/page-*.json >/dev/null 2>&1; then
+            jq -s '{messages: [.[].messages[]?]}' "$pages_dir"/page-*.json \
+              > $WORKFLOW_TEMP/droid-messages.json
+          else
+            echo '{"messages":[]}' > $WORKFLOW_TEMP/droid-messages.json
+          fi
 
           msg_count=$(jq '.messages | length' $WORKFLOW_TEMP/droid-messages.json)
           echo "Fetched $msg_count messages."

--- a/dot_bashrc.tmpl
+++ b/dot_bashrc.tmpl
@@ -20,6 +20,17 @@ export PATH
 # Uncomment the following line if you don't like systemctl's auto-paging feature:
 # export SYSTEMD_PAGER=
 
+# Linuxbrew: ensure Homebrew/Linuxbrew bins are on PATH for bash login shells
+# on Linux. `bash -l` reads `~/.bash_profile` (not `~/.profile`), and the
+# linuxbrew shellenv block in dot_profile.tmpl is therefore skipped on login
+# bash. Duplicating it here closes that gap without leaking the darwin-only
+# atuin/.local/bin env into the bash startup chain (fixes #55).
+{{ if ne .chezmoi.os "darwin" -}}
+if [ -d /home/linuxbrew/.linuxbrew ]; then
+  eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+fi
+{{ end }}
+
 # User specific aliases and functions
 if [ -d ~/.shellrc.d ]; then
     for rc in ~/.shellrc.d/*; do


### PR DESCRIPTION
This PR combines two changes:

1. **Issue Fixer Minion robustness** — make `Fetch session messages` and `Upload droid session artifacts` soft-fail with `continue-on-error: true`. A failure in either step now logs a warning but does not block the final push branch / open PR step, so a successful droid exec is not wasted.

2. **Reconstructed fix for #55** — the agent's earlier run on macOS produced a fix for bash login shells missing linuxbrew PATH on Linux. The branch push failed for an unrelated workflow-permissions reason, so the fix is reconstructed here: add a guarded linuxbrew `brew shellenv` block to `dot_bashrc.tmpl` for non-Darwin hosts.

Closes #55
