### PR TITLE
ci,refactor(shell): shellcheck files

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -10,6 +10,7 @@
 # Repository files that have no place on actual machines.
 README.md
 LICENSE
+scripts
 
 # GitHub Actions workflows and CI prompts are repo-internal only;
 # chezmoi should never deploy them into ~/.

--- a/.github/workflows/lint-shell-templates.yml
+++ b/.github/workflows/lint-shell-templates.yml
@@ -1,0 +1,52 @@
+# .github/workflows/lint-shell-templates.yml
+# =============================================================================
+# Non-blocking lint check for chezmoi shell templates.
+#
+# Renders templates with a non-interactive config and runs shellcheck / zsh -n
+# via scripts/lint-shell-templates.sh. Findings are reported in the job logs and
+# as annotations, but the workflow does not fail the PR.
+# =============================================================================
+name: Lint shell templates
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  lint-shell-templates:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7.0.1
+
+      - name: Install chezmoi
+        run: |
+          sh -c "$(curl -fsLS get.chezmoi.io)" -- -b "$HOME/.local/bin"
+          "$HOME/.local/bin/chezmoi" --version
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Install shellcheck
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
+          shellcheck --version
+
+      - name: Lint shell templates
+        id: lint
+        # Non-blocking: report findings without failing the PR check.
+        continue-on-error: true
+        run: ./scripts/lint-shell-templates.sh
+
+      - name: Report lint status
+        if: always()
+        run: |
+          if [ "${{ steps.lint.outcome }}" = "success" ]; then
+            echo "Shell template lint passed."
+          else
+            echo "::warning::Shell template lint found issues. See the 'Lint shell templates' step for details."
+          fi

--- a/dot_bash_profile.tmpl
+++ b/dot_bash_profile.tmpl
@@ -3,5 +3,6 @@
 # This mirrors the stock /etc/skel/.bash_profile pattern so login shells
 # pick up the same aliases, thefuck, and starship init as non-login shells.
 if [ -f ~/.bashrc ]; then
+    # shellcheck source=/dev/null
     . ~/.bashrc
 fi

--- a/dot_bashrc.tmpl
+++ b/dot_bashrc.tmpl
@@ -8,13 +8,17 @@ shopt -s autocd
 
 # Source global definitions
 if [ -f /etc/bashrc ]; then
+    # shellcheck source=/dev/null
     . /etc/bashrc
 fi
 
 # User specific environment
-if ! [[ "$PATH" =~ "$HOME/.local/bin:$HOME/bin:" ]]; then
-    PATH="$HOME/.local/bin:$HOME/bin:$PATH"
-fi
+# Use a case statement instead of [[ =~ ]] so the PATH prefix is matched
+# literally without shellcheck flagging a quoted regex (SC2076).
+case ":${PATH}:" in
+    *:"$HOME/.local/bin:$HOME/bin:") ;;
+    *) PATH="$HOME/.local/bin:$HOME/bin:$PATH" ;;
+esac
 export PATH
 
 # Uncomment the following line if you don't like systemctl's auto-paging feature:
@@ -35,6 +39,7 @@ fi
 if [ -d ~/.shellrc.d ]; then
     for rc in ~/.shellrc.d/*; do
         if [ -f "$rc" ]; then
+            # shellcheck source=/dev/null
             . "$rc"
         fi
     done
@@ -64,7 +69,9 @@ alias mcrun='mvn spring-boot:run -Dspring.profiles.active=LOCAL'
 # TODO How did you install Z? (override here if not installed via Homebrew.)
 if command -v brew >/dev/null 2>&1; then
     BREW_PREFIX="$(brew --prefix)"
+    # shellcheck source=/dev/null
     [ -f "$BREW_PREFIX/etc/profile.d/z.sh" ] && . "$BREW_PREFIX/etc/profile.d/z.sh"
+    # shellcheck source=/dev/null
     [ -f "$BREW_PREFIX/etc/bash_completion" ] && . "$BREW_PREFIX/etc/bash_completion"
 fi
 
@@ -79,6 +86,7 @@ fi
 # arg matches the documented invocation; the env script currently
 # ignores it but this stays forward-compatible.
 if [ -f "$HOME/.atuin/bin/env" ]; then
+    # shellcheck source=/dev/null
     . "$HOME/.atuin/bin/env" bash
 fi
 if command -v atuin >/dev/null 2>&1; then

--- a/dot_bashrc.tmpl
+++ b/dot_bashrc.tmpl
@@ -12,12 +12,11 @@ if [ -f /etc/bashrc ]; then
 fi
 
 # User specific environment
-# Use a case statement instead of [[ =~ ]] so the PATH prefix is matched
-# literally without shellcheck flagging a quoted regex (SC2076).
-case ":${PATH}:" in
-    *:"$HOME/.local/bin:$HOME/bin:") ;;
-    *) PATH="$HOME/.local/bin:$HOME/bin:$PATH" ;;
-esac
+# Use bash glob matching instead of [[ =~ ]] so shellcheck does not flag
+# a quoted regex (SC2076).
+if [[ ":${PATH}:" != *:"$HOME/.local/bin:$HOME/bin:"* ]]; then
+    PATH="$HOME/.local/bin:$HOME/bin:$PATH"
+fi
 export PATH
 
 # Uncomment the following line if you don't like systemctl's auto-paging feature:

--- a/dot_bashrc.tmpl
+++ b/dot_bashrc.tmpl
@@ -8,7 +8,6 @@ shopt -s autocd
 
 # Source global definitions
 if [ -f /etc/bashrc ]; then
-    # shellcheck source=/dev/null
     . /etc/bashrc
 fi
 
@@ -69,9 +68,7 @@ alias mcrun='mvn spring-boot:run -Dspring.profiles.active=LOCAL'
 # TODO How did you install Z? (override here if not installed via Homebrew.)
 if command -v brew >/dev/null 2>&1; then
     BREW_PREFIX="$(brew --prefix)"
-    # shellcheck source=/dev/null
     [ -f "$BREW_PREFIX/etc/profile.d/z.sh" ] && . "$BREW_PREFIX/etc/profile.d/z.sh"
-    # shellcheck source=/dev/null
     [ -f "$BREW_PREFIX/etc/bash_completion" ] && . "$BREW_PREFIX/etc/bash_completion"
 fi
 
@@ -86,7 +83,6 @@ fi
 # arg matches the documented invocation; the env script currently
 # ignores it but this stays forward-compatible.
 if [ -f "$HOME/.atuin/bin/env" ]; then
-    # shellcheck source=/dev/null
     . "$HOME/.atuin/bin/env" bash
 fi
 if command -v atuin >/dev/null 2>&1; then

--- a/dot_profile.tmpl
+++ b/dot_profile.tmpl
@@ -2,7 +2,9 @@
 # atuin set this up so that I can have access
 # to my history outside of zsh.
 {{ if eq .chezmoi.os "darwin" -}}
+# shellcheck source=/dev/null
 [ -f "$HOME/.atuin/bin/env" ] && . "$HOME/.atuin/bin/env"
+# shellcheck source=/dev/null
 [ -f "$HOME/.local/bin/env" ] && . "$HOME/.local/bin/env"
 {{- end }}
 

--- a/dot_profile.tmpl
+++ b/dot_profile.tmpl
@@ -2,9 +2,7 @@
 # atuin set this up so that I can have access
 # to my history outside of zsh.
 {{ if eq .chezmoi.os "darwin" -}}
-# shellcheck source=/dev/null
 [ -f "$HOME/.atuin/bin/env" ] && . "$HOME/.atuin/bin/env"
-# shellcheck source=/dev/null
 [ -f "$HOME/.local/bin/env" ] && . "$HOME/.local/bin/env"
 {{- end }}
 

--- a/dot_shellrc.d/01-env.sh
+++ b/dot_shellrc.d/01-env.sh
@@ -1,6 +1,8 @@
+# shellcheck shell=bash
 # 01-env.sh — shared environment variables for bash and zsh.
-# Sourced on every interactive shell startup via the ~/.shellrc.d/ loops
-# in dot_bashrc.tmpl and dot_zshrc.tmpl. Keep this file POSIX-compatible.
+# Sourced (not executed) by both bash and zsh via the ~/.shellrc.d/ loops
+# in dot_bashrc.tmpl and dot_zshrc.tmpl, so no shebang applies; checked
+# against bash as the restrictive common denominator. Keep POSIX-compatible.
 
 # Root of the user's workspace tree (projects, scratchpads, etc.).
 export WORKSPACE="${HOME}/workspace"

--- a/dot_shellrc.d/01-env.sh
+++ b/dot_shellrc.d/01-env.sh
@@ -1,8 +1,7 @@
 # shellcheck shell=sh
 # 01-env.sh — shared environment variables for bash and zsh.
-# Sourced by both bash and zsh via the ~/.shellrc.d/ loops,
+# Sourced by bash and zsh via the ~/.shellrc.d/ loops,
 # so no shebang applies.
-# Checked against POSIX sh as the restrictive common denominator.
 
 # Root of the user's workspace tree (projects, scratchpads, etc.).
 export WORKSPACE="${HOME}/workspace"

--- a/dot_shellrc.d/01-env.sh
+++ b/dot_shellrc.d/01-env.sh
@@ -1,8 +1,8 @@
-# shellcheck shell=bash
+# shellcheck shell=sh
 # 01-env.sh — shared environment variables for bash and zsh.
-# Sourced (not executed) by both bash and zsh via the ~/.shellrc.d/ loops
-# in dot_bashrc.tmpl and dot_zshrc.tmpl, so no shebang applies; checked
-# against bash as the restrictive common denominator. Keep POSIX-compatible.
+# Sourced by both bash and zsh via the ~/.shellrc.d/ loops,
+# so no shebang applies.
+# Checked against POSIX sh as the restrictive common denominator.
 
 # Root of the user's workspace tree (projects, scratchpads, etc.).
 export WORKSPACE="${HOME}/workspace"

--- a/dot_shellrc.d/10-droid.sh
+++ b/dot_shellrc.d/10-droid.sh
@@ -1,7 +1,7 @@
 # shellcheck shell=bash
-# ~/.shellrc.d/10-droid.sh — unified droid wrapper.
-# Sourced by both bash and zsh (never executed), so no shebang; checked
-# against bash as the restrictive common denominator.
+# 10-droid.sh — unified droid wrapper.
+# Sourced by both bash and zsh, so no shebang.
+# Checked against bash as the restrictive common denominator.
 #
 # Smart droid wrapper: redirects to nearest trusted folder (or $SCRATCHPAD),
 # unless running a subcommand or an explicit --cwd is given.

--- a/dot_shellrc.d/10-droid.sh
+++ b/dot_shellrc.d/10-droid.sh
@@ -1,13 +1,10 @@
 # shellcheck shell=bash
 # 10-droid.sh — unified droid wrapper.
-# Sourced by both bash and zsh, so no shebang.
-# Checked against bash as the restrictive common denominator.
+# Sourced by bash and zsh, so no shebang applies.
+# Portable to bash 3.2, bash 4+, and zsh 5.x.
 #
 # Smart droid wrapper: redirects to nearest trusted folder (or $SCRATCHPAD),
 # unless running a subcommand or an explicit --cwd is given.
-#
-# Deployed on every host (bash or zsh, any version).
-# Portable to bash 3.2, bash 4+, and zsh 5.x.
 #
 # Portable idioms used here:
 #   - Subcommand membership via case pattern on a space-padded literal,

--- a/dot_shellrc.d/10-droid.sh
+++ b/dot_shellrc.d/10-droid.sh
@@ -1,4 +1,7 @@
+# shellcheck shell=bash
 # ~/.shellrc.d/10-droid.sh — unified droid wrapper.
+# Sourced by both bash and zsh (never executed), so no shebang; checked
+# against bash as the restrictive common denominator.
 #
 # Smart droid wrapper: redirects to nearest trusted folder (or $SCRATCHPAD),
 # unless running a subcommand or an explicit --cwd is given.

--- a/dot_shellrc.d/55-aliases.sh
+++ b/dot_shellrc.d/55-aliases.sh
@@ -1,3 +1,6 @@
+# shellcheck shell=bash
+# 55-aliases.sh — shared aliases, sourced by both bash and zsh (no shebang).
+
 alias g="git"
 alias ll="ls -al"
 alias cm="chezmoi"

--- a/dot_shellrc.d/55-aliases.sh
+++ b/dot_shellrc.d/55-aliases.sh
@@ -1,4 +1,4 @@
-# shellcheck shell=bash
+# shellcheck shell=sh
 # 55-aliases.sh — shared aliases, sourced by both bash and zsh (no shebang).
 
 alias g="git"

--- a/dot_shellrc.d/55-aliases.sh
+++ b/dot_shellrc.d/55-aliases.sh
@@ -1,5 +1,6 @@
 # shellcheck shell=sh
-# 55-aliases.sh — shared aliases, sourced by both bash and zsh (no shebang).
+# 55-aliases.sh — shared aliases.
+# Sourced by bash and zsh, so no shebang applies.
 
 alias g="git"
 alias ll="ls -al"

--- a/scripts/lint-shell-templates.sh
+++ b/scripts/lint-shell-templates.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# lint-shell-templates.sh — render chezmoi shell templates and lint them.
+#
+# Chezmoi templates contain Go template syntax, so shellcheck cannot read
+# them directly. This script renders each template with a non-interactive
+# chezmoi config and runs shellcheck (bash/sh templates) or zsh -n
+# (zsh templates) on the rendered output.
+#
+# Usage:
+#   ./scripts/lint-shell-templates.sh
+#
+# Environment:
+#   SHELLCHECK_SEVERITY — minimum severity to fail on (default: warning).
+#                         Set to "error" to ignore warnings/info, or "info"
+#                         to fail on everything.
+
+set -euo pipefail
+
+shellcheck_severity="${SHELLCHECK_SEVERITY:-warning}"
+
+# Resolve repo root so the script can be run from any working directory.
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
+# Temporary directory for the non-interactive chezmoi config and rendered files.
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+# Non-interactive config with dummy values for every promptBoolOnce /
+# promptStringOnce field used by .chezmoi.toml.tmpl. This lets
+# execute-template run without blocking for input.
+cat > "$tmpdir/chezmoi.toml" <<'EOF'
+[data]
+email = "lint@example.com"
+work = false
+iterm2 = false
+artifactoryHost = ""
+bashMajor = 5
+
+[data.dev]
+java = false
+
+[data.fonts]
+sans-serif = '"Helvetica",sans-serif'
+serif = '"Georgia",serif'
+mono = '"Fira Code Mono"'
+EOF
+
+chezmoi_config="$tmpdir/chezmoi.toml"
+
+# Render a chezmoi template to stdout using the non-interactive config.
+render_template() {
+    local tmpl="$1"
+    chezmoi execute-template --config "$chezmoi_config" < "$tmpl"
+}
+
+# Lint a rendered bash template with shellcheck.
+lint_bash_template() {
+    local tmpl="$1"
+    echo "=== $tmpl (bash) ==="
+    render_template "$tmpl" | shellcheck --severity="$shellcheck_severity" -s bash -
+}
+
+# Lint a rendered POSIX sh template with shellcheck.
+lint_sh_template() {
+    local tmpl="$1"
+    echo "=== $tmpl (sh) ==="
+    render_template "$tmpl" | shellcheck --severity="$shellcheck_severity" -s sh -
+}
+
+# Lint a rendered zsh template with zsh -n (shellcheck does not support zsh).
+lint_zsh_template() {
+    local tmpl="$1"
+    local rendered="$tmpdir/$(basename "$tmpl" .tmpl)"
+    echo "=== $tmpl (zsh) ==="
+    render_template "$tmpl" > "$rendered"
+    if command -v zsh >/dev/null 2>&1; then
+        zsh -n "$rendered"
+    else
+        echo "warning: zsh not found; skipping zsh syntax check for $tmpl" >&2
+    fi
+}
+
+# Lint non-template shell files directly.
+lint_shellrc_d() {
+    echo "=== dot_shellrc.d/*.sh ==="
+    shellcheck --severity="$shellcheck_severity" dot_shellrc.d/*.sh
+}
+
+lint_sh_template dot_profile.tmpl
+lint_bash_template dot_bash_profile.tmpl
+lint_bash_template dot_bashrc.tmpl
+lint_zsh_template dot_zshrc.tmpl
+lint_shellrc_d
+
+echo ""
+echo "All shell templates passed linting."


### PR DESCRIPTION
Adds local and CI linting for shell templates so shellcheck issues are caught before an automated review/security pass has to spend turns on them.

## Changes

- **New script:** `scripts/lint-shell-templates.sh`
  - Renders chezmoi shell templates with a non-interactive config.
  - Runs `shellcheck` on rendered bash/sh templates.
  - Runs `zsh -n` on `dot_zshrc.tmpl`.
  - Runs `shellcheck` directly on `dot_shellrc.d/*.sh`.
  - Supports `SHELLCHECK_SEVERITY=info|warning|error` (default: `warning`).

- **CI workflow:** `.github/workflows/lint-shell-templates.yml`
  - Runs the lint script on every PR and push to `main`.
  - Uses `continue-on-error` so findings are reported in logs without blocking the PR check.

- **Dotfile fixes** to keep the lint script clean at warning severity:
  - Add `# shellcheck source=/dev/null` for dynamic/external sourced files (`. ~/.bashrc`, `. "$rc"`).
  - Replace `[[ "$PATH" =~ "..." ]]` with `[[ ":$PATH:" == *":...:"* ]]` to fix SC2076.

## Testing

```sh
./scripts/lint-shell-templates.sh
```

Run from the repo root; the script resolves its own location and cleans up its temporary chezmoi config.
