### PR TITLE
fix(chezmoi): clean up config template rendering

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -2,23 +2,22 @@
 # from `hasDrDev`/`isDRDevMachine`: any work machine counts, not just
 # DataRobot). The prompt key is reused so existing chezmoi users are not
 # re-prompted; the prompt text is updated to reflect the broader meaning.
-{{ $isWorkMachine := promptBoolOnce . "hasDrDev" "Is this a work machine" }}
-{{ $email := promptStringOnce . "email" "Email address" }}
-{{ $isIterm2Managed := promptBoolOnce . "iterm2" "Manage iTerm2 preferences with chezmoi" }}
-{{ $isJavaDev := promptBoolOnce . "devJava" "Do Java development on this machine" }}
-
-{{ $artifactoryHost := "" }}
-{{- if $isWorkMachine }}
-{{- $artifactoryHost = promptStringOnce . "artifactoryHost" "DataRobot Artifactory hostname" }}
-{{- end }}
+{{- $isWorkMachine := promptBoolOnce . "hasDrDev" "Is this a work machine" -}}
+{{- $email := promptStringOnce . "email" "Email address" -}}
+{{- $isIterm2Managed := promptBoolOnce . "iterm2" "Manage iTerm2 preferences with chezmoi" -}}
+{{- $isJavaDev := promptBoolOnce . "devJava" "Do Java development on this machine" -}}
+{{- $artifactoryHost := "" -}}
+{{- if $isWorkMachine -}}
+{{- $artifactoryHost = promptStringOnce . "artifactoryHost" "DataRobot Artifactory hostname" -}}
+{{- end -}}
 
 # Probe the major version of the bash found in PATH (macOS ships 3.2,
 # Fedora 4.0+). 0 means bash is absent. This runs only at `chezmoi init`
 # time; the result is persisted as data.bashMajor below.
-{{ $bashMajor := 0 -}}
-{{ if lookPath "bash" -}}
-{{ $bashMajor = output "bash" "-c" "echo ${BASH_VERSINFO[0]}" | trim | int -}}
-{{ end -}}
+{{- $bashMajor := 0 -}}
+{{- if lookPath "bash" -}}
+{{- $bashMajor = output "bash" "-c" "echo ${BASH_VERSINFO[0]}" | trim | int -}}
+{{- end -}}
 
 {{- if $isWorkMachine }}
 # age encryption for work-only files that contain internal hostnames,
@@ -30,7 +29,7 @@ encryption = "age"
 [age]
     identity = "{{ .chezmoi.homeDir }}/.config/chezmoi/age-key.txt"
     recipient = "age1d4q6vwcrd8j23hlxvrwz80pce45gqg8rk6z8huufh6w7u735favq4jam8y"
-{{- end }}
+{{ end }}
 
 # `work` is the gate variable for work-only content. See docs/work-dotfiles.md.
 [data]

--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -20,12 +20,12 @@
 {{ $bashMajor = output "bash" "-c" "echo ${BASH_VERSINFO[0]}" | trim | int -}}
 {{ end -}}
 
+{{- if $isWorkMachine }}
 # age encryption for work-only files that contain internal hostnames,
 # JIRA project keys, cloud IDs, etc. Only configured on work machines;
 # non-work machines never need to decrypt (the files are .chezmoiignore'd).
 # Key lives at ~/.config/chezmoi/age-key.txt (not in the repo). See
 # docs/work-dotfiles.md Pattern 4 for details.
-{{- if $isWorkMachine }}
 encryption = "age"
 [age]
     identity = "{{ .chezmoi.homeDir }}/.config/chezmoi/age-key.txt"

--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -20,9 +20,11 @@
 {{- end -}}
 
 [data]
+# `email` is the git-identity email
 email = {{ $email | quote }}
 # `work` is the gate variable for work-only content. See docs/work-dotfiles.md.
 work = {{ $isWorkMachine }}
+# whether iTerm2 configuration is managed by chezmoi
 iterm2 = {{ $isIterm2Managed }}
 # TODO artifactory does not need to live here; this is a work-related
 # data field.

--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -19,18 +19,6 @@
 {{- $bashMajor = output "bash" "-c" "echo ${BASH_VERSINFO[0]}" | trim | int -}}
 {{- end -}}
 
-{{- if $isWorkMachine }}
-# age encryption for work-only files that contain internal hostnames,
-# JIRA project keys, cloud IDs, etc. Only configured on work machines;
-# non-work machines never need to decrypt (the files are .chezmoiignore'd).
-# Key lives at ~/.config/chezmoi/age-key.txt (not in the repo). See
-# docs/work-dotfiles.md Pattern 4 for details.
-encryption = "age"
-[age]
-    identity = "{{ .chezmoi.homeDir }}/.config/chezmoi/age-key.txt"
-    recipient = "age1d4q6vwcrd8j23hlxvrwz80pce45gqg8rk6z8huufh6w7u735favq4jam8y"
-{{ end }}
-
 [data]
 email = {{ $email | quote }}
 # `work` is the gate variable for work-only content. See docs/work-dotfiles.md.
@@ -43,6 +31,18 @@ artifactoryHost = {{ $artifactoryHost | quote }}
 # absent). Kept for future bash-version-specific logic; nothing consumes
 # it yet. Re-run `chezmoi init` to refresh after upgrading bash.
 bashMajor = {{ $bashMajor }}
+
+{{- if $isWorkMachine }}
+# age encryption for work-only files that contain internal hostnames,
+# JIRA project keys, cloud IDs, etc. Only configured on work machines;
+# non-work machines never need to decrypt (the files are .chezmoiignore'd).
+# Key lives at ~/.config/chezmoi/age-key.txt (not in the repo). See
+# docs/work-dotfiles.md Pattern 4 for details.
+encryption = "age"
+[age]
+    identity = "{{ .chezmoi.homeDir }}/.config/chezmoi/age-key.txt"
+    recipient = "age1d4q6vwcrd8j23hlxvrwz80pce45gqg8rk6z8huufh6w7u735favq4jam8y"
+{{ end }}
 
 [data.dev]
 java = {{ $isJavaDev }}

--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -1,19 +1,19 @@
-# `isWorkMachine` is the gating variable for work-only content (renamed
-# from `hasDrDev`/`isDRDevMachine`: any work machine counts, not just
-# DataRobot). The prompt key is reused so existing chezmoi users are not
-# re-prompted; the prompt text is updated to reflect the broader meaning.
-{{- $isWorkMachine := promptBoolOnce . "hasDrDev" "Is this a work machine" -}}
 {{- $email := promptStringOnce . "email" "Email address" -}}
-{{- $isIterm2Managed := promptBoolOnce . "iterm2" "Manage iTerm2 preferences with chezmoi" -}}
+
+{{/* `isWorkMachine` is the gating variable for work-only content. The prompt key hasDrDev is reused so existing chezmoi users are not re-prompted; the prompt text is updated to reflect the broader meaning. */}}
+{{- $isWorkMachine := promptBoolOnce . "hasDrDev" "Is this a work machine" -}}
+
 {{- $isJavaDev := promptBoolOnce . "devJava" "Do Java development on this machine" -}}
+
+{{- $isIterm2Managed := promptBoolOnce . "iterm2" "Manage iTerm2 preferences with chezmoi" -}}
+
+
 {{- $artifactoryHost := "" -}}
 {{- if $isWorkMachine -}}
 {{- $artifactoryHost = promptStringOnce . "artifactoryHost" "DataRobot Artifactory hostname" -}}
 {{- end -}}
 
-# Probe the major version of the bash found in PATH (macOS ships 3.2,
-# Fedora 4.0+). 0 means bash is absent. This runs only at `chezmoi init`
-# time; the result is persisted as data.bashMajor below.
+{{/* Probe the major version of the bash found in PATH (macOS ships 3.2, Fedora 4.0+). 0 means bash is absent. This runs only at `chezmoi init` time; the result is persisted as data.bashMajor below. */}}
 {{- $bashMajor := 0 -}}
 {{- if lookPath "bash" -}}
 {{- $bashMajor = output "bash" "-c" "echo ${BASH_VERSINFO[0]}" | trim | int -}}
@@ -31,11 +31,13 @@ encryption = "age"
     recipient = "age1d4q6vwcrd8j23hlxvrwz80pce45gqg8rk6z8huufh6w7u735favq4jam8y"
 {{ end }}
 
-# `work` is the gate variable for work-only content. See docs/work-dotfiles.md.
 [data]
 email = {{ $email | quote }}
+# `work` is the gate variable for work-only content. See docs/work-dotfiles.md.
 work = {{ $isWorkMachine }}
 iterm2 = {{ $isIterm2Managed }}
+# TODO artifactory does not need to live here; this is a work-related
+# data field.
 artifactoryHost = {{ $artifactoryHost | quote }}
 # Major version of the bash in PATH at `chezmoi init` time (0 if bash is
 # absent). Kept for future bash-version-specific logic; nothing consumes

--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -32,10 +32,7 @@ encryption = "age"
     recipient = "age1d4q6vwcrd8j23hlxvrwz80pce45gqg8rk6z8huufh6w7u735favq4jam8y"
 {{- end }}
 
-# `work` is the gate variable for work-only content. Renamed from `dr`
-# because the meaning is broader than DataRobot development: any work
-# machine is gated through this flag. Templates use `{{ .work }}`
-# directly (no `.dr` alias). See docs/work-dotfiles.md.
+# `work` is the gate variable for work-only content. See docs/work-dotfiles.md.
 [data]
 email = {{ $email | quote }}
 work = {{ $isWorkMachine }}


### PR DESCRIPTION
This PR fixes the `cm init` failure and cleans up the rendered `chezmoi.toml` output:

- Convert init-time implementation comments to template-only `{{/* ... */}}` comments so they don't render in `chezmoi.toml`.
- Move the `work` data-field comment to sit directly above the `work` key.
- Add aggressive whitespace trimming to prompt/assignment actions to eliminate runs of blank lines.
- Move the conditional age-encryption block after the `[data]` section so the rendered file starts with `[data]` even when the block is omitted on non-work machines.
- Add inline comments for the `email` and `iterm2` data fields.