### PR TITLE
feat(shellrc): auto-export AJ_FACTORY_DR_TOKEN on work machines

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -47,4 +47,5 @@ Library/Preferences/com.googlecode.iterm2.plist
 {{- if not .work }}
 workspace/DataRobot
 .claude/skills/tech-debt-epic
+.shellrc.d/06-work-env.sh
 {{- end }}

--- a/dot_shellrc.d/06-work-env.sh
+++ b/dot_shellrc.d/06-work-env.sh
@@ -5,10 +5,8 @@
 # (see docs/work-dotfiles.md Pattern 2) — it does not exist on non-work
 # machines.
 
-# AJ_FACTORY_DR_TOKEN — DataRobot staging API token for Factory's LLM gateway
-# custom models (see ~/.factory/settings.json customModels[].apiKey).
-# Sourced from the DR CLI's own config so it stays in sync with
-# `drconfig.yaml` without a manual export step. Silently no-ops if the DR
+# AJ_FACTORY_DR_TOKEN — API token for wiring Factory to the DataRobot LLM
+# gateway. Sourced from `drconfig.yaml`. Silently no-ops if the DR
 # CLI hasn't been configured yet or yq isn't installed.
 if [ -f "${HOME}/.config/datarobot/drconfig.yaml" ] && command -v yq >/dev/null 2>&1; then
     AJ_FACTORY_DR_TOKEN="$(yq '.token' "${HOME}/.config/datarobot/drconfig.yaml" 2>/dev/null)"

--- a/dot_shellrc.d/06-work-env.sh
+++ b/dot_shellrc.d/06-work-env.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=sh
+# 06-work-env.sh — work-only environment variables.
+# Sourced by bash and zsh via the ~/.shellrc.d/ loops, so no shebang applies.
+# This whole file is gated to work machines only via .chezmoiignore
+# (see docs/work-dotfiles.md Pattern 2) — it does not exist on non-work
+# machines.
+
+# AJ_FACTORY_DR_TOKEN — DataRobot staging API token for Factory's LLM gateway
+# custom models (see ~/.factory/settings.json customModels[].apiKey).
+# Sourced from the DR CLI's own config so it stays in sync with
+# `drconfig.yaml` without a manual export step. Silently no-ops if the DR
+# CLI hasn't been configured yet or yq isn't installed.
+if [ -f "${HOME}/.config/datarobot/drconfig.yaml" ] && command -v yq >/dev/null 2>&1; then
+    AJ_FACTORY_DR_TOKEN="$(yq '.token' "${HOME}/.config/datarobot/drconfig.yaml" 2>/dev/null)"
+    [ -n "$AJ_FACTORY_DR_TOKEN" ] && [ "$AJ_FACTORY_DR_TOKEN" != "null" ] && export AJ_FACTORY_DR_TOKEN
+fi


### PR DESCRIPTION
## Summary
- Adds `dot_shellrc.d/06-work-env.sh`, exporting `AJ_FACTORY_DR_TOKEN` on shell start by reading the token out of `~/.config/datarobot/drconfig.yaml` (same `yq` pattern already used in `starship.toml.tmpl`).
- Removes the need to manually export a token before Factory's LLM gateway custom models can authenticate.
- Gated to work machines only via `.chezmoiignore` (`docs/work-dotfiles.md` Pattern 2) — non-work machines never get this file.

## Follow-up (manual, not chezmoi-managed)
`~/.factory/settings.json` is not chezmoi-managed. After applying this change, update its `customModels[].apiKey` entries from `${DR_STAGING_API_TOKEN}` to `${AJ_FACTORY_DR_TOKEN}` by hand.

## Verification
- `shellcheck dot_shellrc.d/06-work-env.sh dot_shellrc.d/01-env.sh` passes.
- Not yet verified end-to-end against a live `drconfig.yaml`/Factory session — please confirm after applying with `chezmoi apply`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
