### PR TITLE
feat(ci): add Sweeper Minion weekly dotfile consistency sweep

### DIFF
--- a/.github/prompts/consistency-sweep.md
+++ b/.github/prompts/consistency-sweep.md
@@ -1,0 +1,84 @@
+<!-- .github/prompts/consistency-sweep.md -->
+<!--
+  Reusable prompt template for the droid-consistency-sweep GitHub Action
+  ("Sweeper Minion").
+
+  The workflow appends the sweep-results JSON (per-file failures from
+  scripts/consistency-sweep.sh) after the `---` separator below before
+  passing this file to `droid exec`.
+-->
+
+# Task: Draft GitHub issues for dotfile consistency failures
+
+You are running headlessly inside a GitHub Actions workflow. A scripted
+validation suite has already run `shellcheck`, `chezmoi execute-template`,
+`bash -n`, and `zsh -n` across this chezmoi dotfiles repo. Its results are
+appended below the `---` separator as JSON.
+
+Your job is to **author GitHub issue content** (titles + bodies) for the
+failures and write them to disk. A scripted step will create the issues with
+`gh issue create` — **do not run `gh`, do not push, do not edit any repo
+files.** You only write files under `.droid-temp/issues/`.
+
+## Output contract
+
+Write exactly **one Markdown file per issue** plus a **manifest** that the
+scripted step reads. All output goes under `.droid-temp/issues/`.
+
+### Manifest: `.droid-temp/issues/manifest.json`
+
+A JSON array. Each entry:
+
+```json
+{
+  "slug": "dot-bashrc-tmpl",
+  "title": "[sweeper] dot_bashrc.tmpl — shellcheck warnings",
+  "file": "dot_bashrc.tmpl",
+  "body_file": "dot-bashrc-tmpl.md"
+}
+```
+
+- `slug` — short, stable, filesystem-safe identifier (lowercase, hyphenated).
+  Used for dedup, so keep it deterministic across runs for the same file.
+- `title` — starts with `[sweeper]` and names the file + a one-phrase summary.
+- `file` — the repo-relative path of the failing file (from the JSON `file`
+  field). Use `"__summary__"` for a single summary issue.
+- `body_file` — filename of the Markdown body inside `.droid-temp/issues/`.
+
+### Body files: `.droid-temp/issues/<slug>.md`
+
+GitHub-flavored Markdown. For a per-file issue include:
+
+- The failing file path and a short description of what the check does.
+- A fenced block quoting the relevant check output (trim very long output to
+  the most actionable ~40 lines; note when truncated).
+- A "Suggested fix" section with concrete, specific guidance grounded in the
+  actual output — do not invent problems that are not in the JSON.
+
+For a summary issue, list every failing file with its checks and link-worthy
+paths, followed by an aggregate "Next steps" section.
+
+## Grouping rule
+
+The workflow decides grouping, but apply it here when shaping the manifest:
+
+- **1–3 failing files** → one issue per file (`file` = the file path).
+- **4 or more failing files** → a single summary issue (`file` = `"__summary__"`)
+  covering all of them.
+
+If you judge that one failure is clearly trivial and worth folding into
+another, you may — but never drop a failing file entirely. Every `file` in the
+input JSON must be represented somewhere in the manifest.
+
+## Before you start
+
+1. Read `AGENTS.md` in the repo root for project conventions.
+2. You may read the failing files in the repo to ground your suggested fixes,
+   but **do not modify them**.
+
+## Quality bar
+
+- Ground every claim in the appended JSON output. Do not report issues that
+  are not present in the data.
+- Keep titles under 72 characters.
+- Prefer specific, copy-pasteable fix advice over generic platitudes.

--- a/.github/workflows/droid-consistency-sweep.yml
+++ b/.github/workflows/droid-consistency-sweep.yml
@@ -27,15 +27,6 @@ on:
     # spikes). Distinct from Builder Minion (Thu–Mon 09:17), Meter Reader
     # Minion (Tue 09:53), and Security Review Minion (Wed 10:37).
     - cron: "11 10 * * 0"
-  # TEMPORARY: pull_request trigger exists only to validate this workflow
-  # from the feature branch before merge (GitHub registers workflow_dispatch
-  # workflows on the default branch only). Remove this trigger before opening
-  # the final PR — the production triggers are schedule + workflow_dispatch.
-  pull_request:
-    paths:
-      - .github/workflows/droid-consistency-sweep.yml
-      - scripts/consistency-sweep.sh
-      - .github/prompts/consistency-sweep.md
 
 permissions:
   contents: read

--- a/.github/workflows/droid-consistency-sweep.yml
+++ b/.github/workflows/droid-consistency-sweep.yml
@@ -1,0 +1,473 @@
+# .github/workflows/droid-consistency-sweep.yml
+# =============================================================================
+# Scheduled + manual GitHub Action that runs a headless dotfile consistency
+# sweep ("Sweeper Minion"). It runs shellcheck, `chezmoi execute-template`,
+# `bash -n`, and `zsh -n` across the whole chezmoi source tree via
+# scripts/consistency-sweep.sh, then opens GitHub issues for anything broken.
+#
+# Issue authoring is delegated to `droid exec` (it drafts titles + bodies);
+# all outward writes (gh issue create / comment) happen in scripted steps —
+# the agent never runs gh or pushes, matching the Builder / Meter Reader
+# minion convention.
+#
+# Auth/quota/credit failures from droid exec are quiet (green run + warning
+# annotation) so a depleted Factory account does not spam your inbox every
+# week. On a quiet skip, no issues are created.
+#
+# Runner: ubuntu-latest only. zsh is preinstalled on ubuntu-latest, so the
+# `zsh -n` checks run (they are skipped with a warning on runners without
+# zsh — see scripts/consistency-sweep.sh).
+# =============================================================================
+name: Sweeper Minion
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Runs weekly on Sundays at 10:11 UTC (off-the-hour to avoid GitHub cron
+    # spikes). Distinct from Builder Minion (Thu–Mon 09:17), Meter Reader
+    # Minion (Tue 09:53), and Security Review Minion (Wed 10:37).
+    - cron: "11 10 * * 0"
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: droid-consistency-sweep
+  cancel-in-progress: false
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    # The validation suite is fast; droid exec (when failures exist) is well
+    # under 10 min, but give it room.
+    timeout-minutes: 30
+    defaults:
+      run:
+        shell: bash
+    steps:
+      # ------------------------------------------------------------------
+      # 1. Checkout
+      # ------------------------------------------------------------------
+      - name: Checkout
+        uses: actions/checkout@v7.0.1
+
+      # ------------------------------------------------------------------
+      # 2. Set up a cross-platform temp directory inside the workspace
+      # ------------------------------------------------------------------
+      - name: Set workflow temp directory
+        id: temp
+        run: |
+          # Keep temp files under the repo workspace so relative paths are
+          # stable. Run after checkout so actions/checkout does not wipe it.
+          WORKFLOW_TEMP="$GITHUB_WORKSPACE/.droid-temp"
+          mkdir -p "$WORKFLOW_TEMP"
+          echo "WORKFLOW_TEMP=$WORKFLOW_TEMP" >> "$GITHUB_ENV"
+          echo "Workflow temp: $WORKFLOW_TEMP"
+
+      # ------------------------------------------------------------------
+      # 3. Install chezmoi (for template rendering)
+      # ------------------------------------------------------------------
+      # Verbatim from droid-issue-fixer.yml (Builder Minion).
+      # ------------------------------------------------------------------
+      - name: Install chezmoi
+        run: |
+          sh -c "$(curl -fsLS get.chezmoi.io)" -- -b "$HOME/.local/bin"
+          "$HOME/.local/bin/chezmoi" --version
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      # ------------------------------------------------------------------
+      # 4. Write CI chezmoi config
+      # ------------------------------------------------------------------
+      # Copied from droid-issue-fixer.yml with two added keys: `hasDrDev` and
+      # `devJava`. These back the promptBoolOnce calls in .chezmoi.toml.tmpl
+      # so that template renders headlessly. (scripts/consistency-sweep.sh
+      # still skips .chezmoi.toml.tmpl because `chezmoi execute-template` run
+      # standalone does not define the promptOnce functions at all — see the
+      # script header — but the keys are harmless and keep the config usable
+      # for `chezmoi init --generate` if ever needed.)
+      # ------------------------------------------------------------------
+      - name: Write CI chezmoi config
+        run: |
+          mkdir -p "$HOME/.config/chezmoi"
+          printf '%s\n' \
+            '[data]' \
+            'email = "droid-ci@example.com"' \
+            'work = false' \
+            'hasDrDev = false' \
+            'iterm2 = false' \
+            'artifactoryHost = ""' \
+            'bashMajor = 5' \
+            '[data.dev]' \
+            'java = false' \
+            'devJava = false' \
+            '[data.fonts]' \
+            'sans-serif = "\"Helvetica\",sans-serif"' \
+            'serif = "\"Georgia\",serif"' \
+            'mono = "\"Fira Code Mono\""' \
+            > "$HOME/.config/chezmoi/chezmoi.toml"
+          echo "CHEZMOI_CI_CONFIG=$HOME/.config/chezmoi/chezmoi.toml" >> "$GITHUB_ENV"
+
+      # ------------------------------------------------------------------
+      # 5. Install shellcheck
+      # ------------------------------------------------------------------
+      # Verbatim cross-platform step from droid-issue-fixer.yml. On the
+      # ubuntu-latest runner only the Linux branch fires, but the full case
+      # is kept so the step stays portable if the runner ever changes.
+      # ------------------------------------------------------------------
+      - name: Install shellcheck
+        run: |
+          if command -v shellcheck >/dev/null 2>&1; then
+            echo "shellcheck already available"
+            shellcheck --version
+            exit 0
+          fi
+
+          case "$RUNNER_OS" in
+            macOS)
+              export HOMEBREW_NO_REQUIRE_TAP_TRUST=1
+              brew install shellcheck
+              ;;
+            Windows)
+              choco install shellcheck
+              ;;
+            Linux)
+              sudo apt-get update && sudo apt-get install -y shellcheck
+              ;;
+          esac
+          shellcheck --version
+
+      # ------------------------------------------------------------------
+      # 6. Run the consistency sweep
+      # ------------------------------------------------------------------
+      # The script always exits 0; failures are encoded in the JSON report.
+      # ------------------------------------------------------------------
+      - name: Run consistency sweep
+        id: sweep
+        run: |
+          scripts/consistency-sweep.sh "$WORKFLOW_TEMP/sweep-results.json"
+          failures=$(jq '.summary.failures' "$WORKFLOW_TEMP/sweep-results.json")
+          files_checked=$(jq '.summary.files_checked' "$WORKFLOW_TEMP/sweep-results.json")
+          echo "Files checked: $files_checked"
+          echo "Failures: $failures"
+          echo "failures=$failures" >> "$GITHUB_OUTPUT"
+          {
+            echo "## Sweeper Minion — validation results"
+            echo ""
+            echo "- Files checked: **$files_checked**"
+            echo "- Failures: **$failures**"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # ------------------------------------------------------------------
+      # 7. Short-circuit when the tree is clean
+      # ------------------------------------------------------------------
+      - name: Check for failures
+        id: haswork
+        run: |
+          if [ "${{ steps.sweep.outputs.failures }}" -gt 0 ]; then
+            echo "has_failures=true" >> "$GITHUB_OUTPUT"
+            echo "Failures detected — proceeding to issue authoring."
+          else
+            echo "has_failures=false" >> "$GITHUB_OUTPUT"
+            echo "No failures — tree is clean. Done."
+            {
+              echo ""
+              echo "✅ No consistency failures. No issues to create."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      # ------------------------------------------------------------------
+      # 8. Install Droid CLI (only when there are failures to report)
+      # ------------------------------------------------------------------
+      # Verbatim from droid-issue-fixer.yml.
+      # ------------------------------------------------------------------
+      - name: Install Droid CLI
+        if: steps.haswork.outputs.has_failures == 'true'
+        run: |
+          curl -fsSL https://app.factory.ai/cli | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/droid" --version
+
+      # ------------------------------------------------------------------
+      # 9. Build the prompt file
+      # ------------------------------------------------------------------
+      - name: Build prompt
+        if: steps.haswork.outputs.has_failures == 'true'
+        run: |
+          cat .github/prompts/consistency-sweep.md > $WORKFLOW_TEMP/prompt.md
+          {
+            echo ""
+            echo "---"
+            echo ""
+            echo "## Sweep results (JSON)"
+            echo ""
+            echo '```json'
+            jq '.' "$WORKFLOW_TEMP/sweep-results.json"
+            echo '```'
+          } >> $WORKFLOW_TEMP/prompt.md
+          echo "Prompt file built ($(wc -l < $WORKFLOW_TEMP/prompt.md) lines)."
+
+      # ------------------------------------------------------------------
+      # 10. Run droid exec (capture exit code, do not fail the step)
+      # ------------------------------------------------------------------
+      - name: Run droid exec
+        id: droid
+        if: steps.haswork.outputs.has_failures == 'true'
+        env:
+          FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
+        run: |
+          set +e
+          droid exec \
+            --auto medium \
+            --model kimi-k2.7-code \
+            --output-format json \
+            -f $WORKFLOW_TEMP/prompt.md \
+            2>&1 | tee $WORKFLOW_TEMP/droid-out.json
+          droid_exit=$?
+          echo "droid_exit=$droid_exit" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      # ------------------------------------------------------------------
+      # 11. Classify the droid exec result (quiet-skip on auth/quota/billing)
+      # ------------------------------------------------------------------
+      - name: Classify droid result
+        id: classify
+        if: steps.haswork.outputs.has_failures == 'true'
+        run: |
+          set -euo pipefail
+          droid_exit="${{ steps.droid.outputs.droid_exit }}"
+
+          result_text=""
+          is_error="false"
+          if [ -f $WORKFLOW_TEMP/droid-out.json ]; then
+            result_text=$(jq -r '.result // ""' $WORKFLOW_TEMP/droid-out.json 2>/dev/null || echo "")
+            is_error=$(jq -r '.is_error // false' $WORKFLOW_TEMP/droid-out.json 2>/dev/null || echo "false")
+          fi
+
+          # Auth/quota/billing quiet skip: only when droid exec actually
+          # failed (non-zero exit or is_error=true).
+          if [ "$droid_exit" -ne 0 ] || [ "$is_error" = "true" ]; then
+            quiet_signatures='Authentication failed|invalid.*key|insufficient|quota|limit exceeded|402|403|429|billing|plan limit|rate limit'
+            if echo "$result_text" | grep -iqE "$quiet_signatures"; then
+              echo "::warning::Droid exec hit an auth/quota/billing limit — skipping quietly."
+              echo "Raw droid result (for diagnostics):"
+              echo "$result_text"
+              {
+                echo "## Sweeper Minion — quiet skip"
+                echo ""
+                echo "Droid exec returned a quota/auth/billing error and was skipped quietly."
+                echo "No issues were created this run."
+                echo ""
+                echo "**Result:** $result_text"
+              } >> "$GITHUB_STEP_SUMMARY"
+              echo "quiet_skip=true" >> "$GITHUB_OUTPUT"
+              echo "hard_fail=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+
+          echo "quiet_skip=false" >> "$GITHUB_OUTPUT"
+
+          if [ "$droid_exit" -ne 0 ]; then
+            echo "hard_fail=true" >> "$GITHUB_OUTPUT"
+            echo "::error::Droid exec failed (exit $droid_exit) with an unexpected error."
+            {
+              echo "## Sweeper Minion — droid exec failed"
+              echo ""
+              echo "Droid exec exited with code **$droid_exit**. Falling back to scripted issue bodies."
+              echo ""
+              if [ -f $WORKFLOW_TEMP/droid-out.json ]; then
+                jq -r '.result // "(no result text)"' $WORKFLOW_TEMP/droid-out.json 2>/dev/null \
+                  || cat $WORKFLOW_TEMP/droid-out.json
+              else
+                echo "(no output captured)"
+              fi
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0  # Step succeeds so issue creation can salvage; job fails below.
+          fi
+
+          echo "hard_fail=false" >> "$GITHUB_OUTPUT"
+
+      # ------------------------------------------------------------------
+      # 12. Create or update GitHub issues
+      # ------------------------------------------------------------------
+      # The agent authors issue bodies to .droid-temp/issues/. This step:
+      #   - builds a manifest (prefers the agent's; falls back to a
+      #     deterministic one generated from sweep-results.json when the agent
+      #     output is missing/unparseable or the run hard-failed);
+      #   - computes STABLE titles for dedup (per-file: "[sweeper] <file>",
+      #     summary: "[sweeper] weekly consistency sweep") so weekly reruns
+      #     comment on existing open issues instead of creating duplicates;
+      #   - creates new issues or posts dated comments on existing ones.
+      # ------------------------------------------------------------------
+      - name: Create or update issues
+        if: steps.haswork.outputs.has_failures == 'true' && steps.classify.outputs.quiet_skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          results="$WORKFLOW_TEMP/sweep-results.json"
+          issues_dir="$WORKFLOW_TEMP/issues"
+          mkdir -p "$issues_dir"
+
+          quiet_skip="${{ steps.classify.outputs.quiet_skip }}"
+          hard_fail="${{ steps.classify.outputs.hard_fail }}"
+
+          # --- Ensure the sweeper label exists ----------------------------
+          gh label create sweeper \
+            --description "Opened by the Sweeper Minion consistency sweep" \
+            --color BFD4F2 --force 2>/dev/null || true
+
+          # --- Decide grouping (<=3 per-file, >3 summary) ----------------
+          failure_files=$(jq -r '[.failures[].file] | unique | length' "$results")
+          per_file=0
+          if [ "$failure_files" -le 3 ]; then
+            per_file=1
+          fi
+
+          # --- Build a manifest ------------------------------------------
+          # Prefer the agent's manifest when it is valid JSON with the right
+          # shape and the run did not hard-fail. Otherwise generate a
+          # deterministic fallback manifest + bodies from sweep-results.json.
+          use_agent=0
+          agent_manifest="$issues_dir/manifest.json"
+          if [ "$hard_fail" != "true" ] && [ -f "$agent_manifest" ]; then
+            if jq -e 'type == "array" and all(.[]; has("slug") and has("file") and has("body_file"))' \
+               "$agent_manifest" >/dev/null 2>&1; then
+              use_agent=1
+            fi
+          fi
+
+          if [ "$use_agent" -eq 0 ]; then
+            echo "Using scripted fallback issue bodies."
+            # Generate one body file per entry, plus manifest.json.
+            manifest_entries="[]"
+            if [ "$per_file" -eq 1 ]; then
+              while IFS=$'\t' read -r file checks_json; do
+                slug=$(echo "$file" | tr -c 'a-zA-Z0-9' '-' | tr 'A-Z' 'a-z' | sed 's/^-*//;s/-*$//')
+                body="$issues_dir/${slug}.md"
+                {
+                  echo "### \`$file\`"
+                  echo ""
+                  echo "The weekly consistency sweep reported the following failure(s):"
+                  echo ""
+                  echo "$checks_json" | jq -r '.[] | "**\(.check):**\n\n\`\`\`\n\(.output)\n\`\`\`\n"'
+                } > "$body"
+                manifest_entries=$(echo "$manifest_entries" | jq \
+                  --arg slug "$slug" --arg file "$file" --arg body_file "${slug}.md" \
+                  '. + [{slug: $slug, file: $file, body_file: $body_file}]')
+              done < <(jq -r '.failures | group_by(.file)[] | [.[0].file, (map({check, output}) | tojson)] | @tsv' "$results")
+            else
+              slug="weekly-summary"
+              body="$issues_dir/${slug}.md"
+              {
+                echo "### Weekly consistency sweep — $failure_files failing file(s)"
+                echo ""
+                echo "The weekly sweep reported failures across the following files:"
+                echo ""
+                echo "$results" | jq -r '.failures | group_by(.file)[] | "- **\(.[0].file)** — \(map(.check) | unique | join(", "))"'
+                echo ""
+                echo "See the [full run artifacts] for complete check output."
+                echo ""
+                echo "## Next steps"
+                echo ""
+                echo "Triage each file above; re-run \`scripts/consistency-sweep.sh\` locally to reproduce."
+              } > "$body"
+              manifest_entries=$(echo "$manifest_entries" | jq \
+                --arg slug "$slug" --arg body_file "${slug}.md" \
+                '. + [{slug: $slug, file: "__summary__", body_file: $body_file}]')
+            fi
+            echo "$manifest_entries" > "$agent_manifest"
+          else
+            echo "Using droid-authored issue bodies from $agent_manifest."
+          fi
+
+          # --- Load existing open sweeper issues for dedup ----------------
+          # Map title -> issue number.
+          existing_json="$issues_dir/existing.json"
+          gh issue list --state open --label sweeper --json number,title \
+            > "$existing_json" 2>/dev/null || echo '[]' > "$existing_json"
+
+          created=0
+          commented=0
+          today=$(date -u +%F)
+
+          # --- Iterate manifest entries ----------------------------------
+          n=$(jq 'length' "$agent_manifest")
+          for i in $(seq 0 $((n - 1))); do
+            entry=$(jq -c ".[$i]" "$agent_manifest")
+            file=$(echo "$entry" | jq -r '.file')
+            body_file=$(echo "$entry" | jq -r '.body_file')
+            body_path="$issues_dir/$body_file"
+
+            # Stable title for dedup.
+            if [ "$file" = "__summary__" ]; then
+              title="[sweeper] weekly consistency sweep"
+            else
+              title="[sweeper] $file"
+            fi
+
+            if [ ! -f "$body_path" ]; then
+              echo "warn: body file $body_path missing for $file — skipping."
+              continue
+            fi
+
+            # Look for an existing open sweeper issue with the same title.
+            existing_num=$(jq -r --arg t "$title" \
+              '.[] | select(.title == $t) | .number' "$existing_json" | head -1)
+
+            if [ -n "$existing_num" ]; then
+              # Update: post a dated comment with the fresh body.
+              {
+                echo "### Update — $today"
+                echo ""
+                cat "$body_path"
+              } | gh issue comment "$existing_num" --body-file -
+              commented=$((commented + 1))
+              echo "Updated existing issue #$existing_num ($title)"
+            else
+              issue_url=$(gh issue create \
+                --title "$title" \
+                --body-file "$body_path" \
+                --label sweeper)
+              created=$((created + 1))
+              echo "Created issue: $title — $issue_url"
+            fi
+          done
+
+          {
+            echo ""
+            echo "### Issues"
+            echo ""
+            echo "- New issues created: **$created**"
+            echo "- Existing issues updated: **$commented**"
+            echo "- Grouping: $([ "$per_file" -eq 1 ] && echo 'one per file' || echo 'single summary')"
+            echo "- Issue source: $([ "$use_agent" -eq 1 ] && echo 'droid-authored' || echo 'scripted fallback')"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # ------------------------------------------------------------------
+      # 13. Upload artifacts (sweep results + droid session)
+      # ------------------------------------------------------------------
+      - name: Upload artifacts
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: sweeper-${{ github.run_id }}
+          path: |
+            .droid-temp/sweep-results.json
+            .droid-temp/prompt.md
+            .droid-temp/droid-out.json
+            .droid-temp/issues
+          if-no-files-found: warn
+          retention-days: 30
+
+      # ------------------------------------------------------------------
+      # 14. Fail the job on unexpected droid hard failure
+      # ------------------------------------------------------------------
+      - name: Fail on hard error
+        if: steps.haswork.outputs.has_failures == 'true' && steps.classify.outputs.hard_fail == 'true'
+        run: |
+          echo "Droid exec had an unexpected hard failure — failing the job."
+          exit 1

--- a/.github/workflows/droid-consistency-sweep.yml
+++ b/.github/workflows/droid-consistency-sweep.yml
@@ -27,6 +27,15 @@ on:
     # spikes). Distinct from Builder Minion (Thu–Mon 09:17), Meter Reader
     # Minion (Tue 09:53), and Security Review Minion (Wed 10:37).
     - cron: "11 10 * * 0"
+  # TEMPORARY: pull_request trigger exists only to validate this workflow
+  # from the feature branch before merge (GitHub registers workflow_dispatch
+  # workflows on the default branch only). Remove this trigger before opening
+  # the final PR — the production triggers are schedule + workflow_dispatch.
+  pull_request:
+    paths:
+      - .github/workflows/droid-consistency-sweep.yml
+      - scripts/consistency-sweep.sh
+      - .github/prompts/consistency-sweep.md
 
 permissions:
   contents: read

--- a/scripts/consistency-sweep.sh
+++ b/scripts/consistency-sweep.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# consistency-sweep.sh — headless dotfile consistency sweep.
+#
+# Runs every static check listed in issue #137 across the whole chezmoi source
+# tree and emits a machine-readable JSON report of *all* failures. The script
+# never exits non-zero on a check failure — failures are encoded in the JSON so
+# a downstream CI step can open one GitHub issue per failing file (or a single
+# summary issue). It only exits non-zero on an internal/setup error.
+#
+# Checks performed:
+#   1. shellcheck on every tracked *.sh file (dialect inferred from name).
+#   2. `chezmoi execute-template` render of every tracked *.tmpl file.
+#   3. `bash -n` syntax check on rendered bash templates + *.sh bash files.
+#   4. `zsh -n`  syntax check on rendered zsh templates (skipped, not failed,
+#      when zsh is unavailable — e.g. on a runner without zsh).
+#
+# Usage:
+#   scripts/consistency-sweep.sh [results.json]
+#
+# Environment:
+#   CHEZMOI_CI_CONFIG — path to a non-interactive chezmoi config. Required for
+#                       template rendering; without it every .tmpl render is
+#                       recorded as a failure with a clear message.
+#   SHELLCHECK_SEVERITY — minimum severity to report (default: warning).
+
+set -uo pipefail
+
+shellcheck_severity="${SHELLCHECK_SEVERITY:-warning}"
+results_file="${1:-$(mktemp -t consistency-sweep-results.XXXXXX.json)}"
+
+# Resolve repo root so the script works from any working directory.
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root" || exit 1
+
+# Temporary scratch space for rendered templates. Cleaned up on exit.
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+chezmoi_config="${CHEZMOI_CI_CONFIG:-}"
+have_chezmoi=0
+have_shellcheck=0
+have_bash=0
+have_zsh=0
+command -v chezmoi    >/dev/null 2>&1 && have_chezmoi=1
+command -v shellcheck >/dev/null 2>&1 && have_shellcheck=1
+command -v bash       >/dev/null 2>&1 && have_bash=1
+command -v zsh        >/dev/null 2>&1 && have_zsh=1
+
+# Build the JSON failure array incrementally with jq. Start empty and append.
+failures_file="$tmpdir/failures.json"
+echo '[]' > "$failures_file"
+
+# add_failure <file> <check> <output>
+# Append one failure record. `output` is read from stdin so multi-line check
+# output (including quotes/newlines) is safely JSON-encoded by jq.
+add_failure() {
+    local file="$1" check="$2" output
+    output="$(cat)"
+    jq --arg file "$file" --arg check "$check" --arg output "$output" \
+        '. + [{file: $file, check: $check, output: $output}]' \
+        "$failures_file" > "$failures_file.tmp" && mv "$failures_file.tmp" "$failures_file"
+}
+
+# run_check <file> <check> <cmd...>
+# Run a command, capturing combined stdout+stderr. On non-zero exit, record a
+# failure. A zero exit with non-empty shellcheck output (warnings at the chosen
+# severity) is also treated as a failure so findings surface as issues.
+run_check() {
+    local file="$1" check="$2"; shift 2
+    local out rc
+    out="$("$@" 2>&1)" && rc=$? || rc=$?
+    if [ "$rc" -ne 0 ]; then
+        printf '%s' "$out" | add_failure "$file" "$check"
+    elif [ "$check" = "shellcheck" ] && [ -n "$out" ]; then
+        # The linter returns 0 but prints findings at the configured severity;
+        # treat any non-empty output as a failure so findings become issues.
+        printf '%s' "$out" | add_failure "$file" "$check"
+    fi
+}
+
+# render <tmpl> -> stdout  (failures recorded by the caller via run_check)
+render() {
+    local tmpl="$1"
+    if [ "$have_chezmoi" -ne 1 ]; then
+        echo "chezmoi not found on PATH" >&2
+        return 127
+    fi
+    if [ -z "$chezmoi_config" ]; then
+        echo "CHEZMOI_CI_CONFIG is unset; cannot render templates headlessly" >&2
+        return 2
+    fi
+    chezmoi execute-template --config "$chezmoi_config" < "$tmpl"
+}
+
+# Infer the shellcheck dialect of a tracked *.sh file: *bash* -> bash, else sh.
+dialect_of() {
+    case "$1" in
+        *bash*) echo bash ;;
+        *)      echo sh   ;;
+    esac
+}
+
+# Classify a *.tmpl file by target shell. Returns "bash", "zsh", "sh", or "".
+# An empty result means the template is not a shell file (e.g. dot_Rprofile.tmpl
+# is R, dot_gitconfig.tmpl is git INI) — only the render check applies to it.
+#
+# dot_profile.tmpl is matched explicitly (not via a *profile* glob) so that
+# dot_Rprofile.tmpl is not mistaken for a POSIX sh template.
+shell_kind_of_template() {
+    local base="$1"
+    case "$base" in
+        *bash*)                echo bash ;;
+        *zsh*)                 echo zsh  ;;
+        *.sh.tmpl|dot_profile.tmpl) echo sh  ;;
+        *)                     echo ""   ;;
+    esac
+}
+
+echo "Consistency sweep — $(date -u +%FT%TZ)"
+echo "repo:        $repo_root"
+echo "chezmoi:     ${have_chezmoi:+yes}${have_chezmoi:-missing}  shellcheck: ${have_shellcheck:+yes}${have_shellcheck:-missing}"
+echo "bash:        ${have_bash:+yes}${have_bash:-missing}  zsh:        ${have_zsh:+yes}${have_zsh:-missing}"
+echo "config:      ${chezmoi_config:-<unset>}"
+echo "severity:    $shellcheck_severity"
+echo
+
+# ---------------------------------------------------------------------------
+# 1. shellcheck + bash -n on tracked *.sh files
+# ---------------------------------------------------------------------------
+sh_files="$(git ls-files '*.sh')"
+files_checked=0
+if [ -n "$sh_files" ]; then
+    for f in $sh_files; do
+        files_checked=$((files_checked + 1))
+        d="$(dialect_of "$f")"
+        if [ "$have_shellcheck" -eq 1 ]; then
+            run_check "$f" "shellcheck" shellcheck --severity="$shellcheck_severity" -s "$d" "$f"
+        fi
+        if [ "$d" = bash ] && [ "$have_bash" -eq 1 ]; then
+            run_check "$f" "bash -n" bash -n "$f"
+        fi
+    done
+else
+    echo "No tracked *.sh files found."
+fi
+
+# ---------------------------------------------------------------------------
+# 2-4. Render every tracked *.tmpl, then shellcheck / bash -n / zsh -n
+#      according to the template's target shell (inferred from name).
+# ---------------------------------------------------------------------------
+tmpl_files="$(git ls-files '*.tmpl')"
+if [ -n "$tmpl_files" ]; then
+    for t in $tmpl_files; do
+        files_checked=$((files_checked + 1))
+
+        # .chezmoi.toml.tmpl uses promptStringOnce/promptBoolOnce, which are
+        # only defined during `chezmoi init` — `chezmoi execute-template` (run
+        # standalone) errors with `function "promptStringOnce" not defined`.
+        # Skip it with a note; this matches scripts/lint-shell-templates.sh.
+        if [ "$t" = ".chezmoi.toml.tmpl" ]; then
+            echo "skip: .chezmoi.toml.tmpl requires chezmoi init (promptOnce funcs); execute-template cannot render it standalone"
+            continue
+        fi
+
+        # Render to a scratch file so syntax-check tools can read it.
+        rendered="$tmpdir/$(basename "$t")"
+        if render "$t" > "$rendered" 2>"$tmpdir/render.err"; then
+            : # rendered ok
+        else
+            cat "$tmpdir/render.err" | add_failure "$t" "chezmoi execute-template"
+            continue  # cannot lint an unrenderable template
+        fi
+
+        kind="$(shell_kind_of_template "$(basename "$t")")"
+        case "$kind" in
+            bash)
+                if [ "$have_shellcheck" -eq 1 ]; then
+                    run_check "$t" "shellcheck" shellcheck --severity="$shellcheck_severity" -s bash "$rendered"
+                fi
+                if [ "$have_bash" -eq 1 ]; then
+                    run_check "$t" "bash -n" bash -n "$rendered"
+                fi
+                ;;
+            zsh)
+                if [ "$have_shellcheck" -eq 1 ]; then
+                    # No native zsh dialect; run as sh to catch cross-shell
+                    # issues, but record under a distinct check name so the
+                    # issue body is accurate.
+                    run_check "$t" "shellcheck(sh)" shellcheck --severity="$shellcheck_severity" -s sh "$rendered"
+                fi
+                if [ "$have_zsh" -eq 1 ]; then
+                    run_check "$t" "zsh -n" zsh -n "$rendered"
+                else
+                    echo "skip: zsh not found; skipping zsh -n for $t"
+                fi
+                ;;
+            sh)
+                if [ "$have_shellcheck" -eq 1 ]; then
+                    run_check "$t" "shellcheck" shellcheck --severity="$shellcheck_severity" -s sh "$rendered"
+                fi
+                ;;
+            "")
+                # Non-shell template (R, git INI, etc.) — render check only.
+                ;;
+        esac
+    done
+else
+    echo "No tracked *.tmpl files found."
+fi
+
+# ---------------------------------------------------------------------------
+# Assemble final report
+# ---------------------------------------------------------------------------
+failures_count="$(jq 'length' "$failures_file")"
+jq -n \
+    --argjson failures "$failures_count" \
+    --argjson files "$files_checked" \
+    --slurpfile f "$failures_file" \
+    '{summary: {files_checked: $files, failures: $failures}, failures: $f[0]}' \
+    > "$results_file"
+
+echo
+echo "Sweep complete: $files_checked file(s) checked, $failures_count failure(s)."
+echo "Report written to: $results_file"
+
+# Always exit 0 — failures live in the JSON. Non-zero is reserved for setup
+# errors (which would have aborted earlier via `set -u`/missing-tool checks).
+exit 0


### PR DESCRIPTION
## Summary

Implements #137 — the **Sweeper Minion**, a weekly scheduled GitHub Action that runs a headless dotfile consistency sweep and opens issues for anything broken.

### Validation suite (`scripts/consistency-sweep.sh`)
- `shellcheck` on every tracked `*.sh` file (dialect inferred from name)
- `chezmoi execute-template` render of every tracked `*.tmpl` file
- `bash -n` on rendered bash templates + bash `*.sh` files
- `zsh -n` on rendered zsh templates (skipped, not failed, when zsh is absent)

The script never fails fast — all failures are collected into a JSON report (per file, per check, with output). Non-shell templates (`dot_Rprofile.tmpl` = R, `dot_gitconfig.tmpl` = git INI) get the render check only. `.chezmoi.toml.tmpl` is skipped because `chezmoi execute-template` standalone doesn't define the `promptOnce` functions (matching `scripts/lint-shell-templates.sh`).

### Issue pipeline
- `droid exec` authors issue titles + bodies to `.droid-temp/issues/`; all outward writes (`gh issue create` / comment) happen in scripted steps — the agent never runs `gh` or pushes (Builder / Meter Reader minion convention).
- **Dedup:** stable titles (`[sweeper] <file>` / `[sweeper] weekly consistency sweep`) so weekly reruns comment on existing open `sweeper`-labeled issues instead of creating duplicates.
- **Grouping:** 1–3 failing files → one issue per file; 4+ → single summary.
- Deterministic scripted fallback generates bodies from `sweep-results.json` when the agent output is missing/unparseable or the run hard-failed.

### Patterns reused from Builder Minion
- quiet-skip on auth/quota/billing (green run + warning, no issues created)
- Install Droid CLI / chezmoi / shellcheck steps (CI chezmoi config gains `hasDrDev` + `devJava` keys for headless `promptBoolOnce`)
- session artifact upload (30-day retention)
- fail the job on unexpected droid hard failure

### Notes
- Runner: `ubuntu-latest` (zsh preinstalled).
- `permissions: contents: read, issues: write`.
- No existing workflow files modified.
- The `pull_request` trigger in the workflow file is **temporary** (for branch validation only) and is removed in a later commit on this branch before merge.

Closes #137.
