### PR TITLE
feat(ci): add Cherry Picker Minion scheduled TODO harvester workflow

### DIFF
--- a/.github/prompts/todo-harvest.md
+++ b/.github/prompts/todo-harvest.md
@@ -1,0 +1,81 @@
+<!-- .github/prompts/todo-harvest.md -->
+<!--
+  Reusable prompt template for the droid-todo-harvester GitHub Action
+  ("Cherry Picker Minion"). The workflow appends the harvested TODO list
+  (as JSON) after the "---" separator below, then runs `droid exec` with it.
+
+  The agent drafts JIRA-ready GitHub issue bodies — one per actionable TODO —
+  into .droid-temp/issues/<slug>.md plus a manifest.json. It never runs gh or
+  git: all outward writes happen in scripted workflow steps, matching the
+  Builder / Meter Reader / Sweeper Minion convention.
+-->
+
+You are a TODO discovery and JIRA issue draft generator running headlessly in
+CI for the "Cherry Picker Minion" workflow.
+
+A repo-wide harvest of `TODO` / `FIXME` / `XXX` comments has already been
+performed; the results are appended below as JSON. Each entry has `file`,
+`line`, `kind`, and `text`. Do NOT re-scan the repo yourself — use only the
+provided JSON.
+
+## Task
+
+For each TODO entry in the JSON:
+
+1. Read 10–20 lines of surrounding code at `file:line` to infer intent and
+   scope. Skip an entry only if the comment is clearly a false positive
+   (e.g. the word "todo" appears inside a URL, a base32 string, or a license
+   block with no actionable task).
+
+2. Draft one JIRA-ready issue body in Atlassian markdown, **under 200 words**,
+   with these sections:
+
+   - **Summary** — one sentence naming the task.
+   - **User story** — As a… I want… so that…
+   - **Acceptance criteria** — bullets in Given/When/Then form.
+   - **Scenarios** — the key case(s) to cover.
+   - **Considerations** — risks, dependencies, or unknowns.
+
+3. Write each draft to `.droid-temp/issues/<slug>.md`, where `<slug>` is a
+   short, stable, filesystem-safe identifier derived from the file path and
+   line (e.g. `scripts-harvest-todos-L42`). Include a header line at the top
+   of each file:
+
+   `### [todo] <file>:<line> — <kind>`
+
+   …so the scripted step can use it as the GitHub issue title anchor.
+
+4. Write `.droid-temp/issues/manifest.json` — a JSON array, one object per
+   drafted issue, with this exact shape:
+
+   ```json
+   [
+     { "slug": "scripts-harvest-todos-L42", "file": "scripts/harvest-todos.sh",
+       "line": 42, "kind": "TODO", "title": "[todo] scripts/harvest-todos.sh:42 — TODO",
+       "body_file": "scripts-harvest-todos-L42.md" }
+   ]
+   ```
+
+   - `slug` must be unique across the manifest and match the body filename
+     (minus the `.md`).
+   - `title` must start with `[todo] ` and contain the `file:line` location so
+     the scripted dedup step can match existing open issues by title.
+   - `body_file` is the basename of the file inside `.droid-temp/issues/`.
+
+## Constraints
+
+- Output ONLY the issue draft files + manifest.json. No reasoning,
+  chain-of-thought, or extra prose in stdout.
+- Do NOT run `gh`, `git`, or any network command. Do NOT edit source files,
+  commit, or push. The only writes you make are the draft files under
+  `.droid-temp/issues/`.
+- If no TODO entries are provided, write an empty `manifest.json` (`[]`) and
+  exit.
+
+---
+
+## Harvested TODOs (JSON)
+
+```json
+[]
+```

--- a/.github/prompts/todo-harvest.md
+++ b/.github/prompts/todo-harvest.md
@@ -74,8 +74,5 @@ For each TODO entry in the JSON:
 
 ---
 
-## Harvested TODOs (JSON)
+<!-- The workflow appends the harvested TODO list as JSON after this line. -->
 
-```json
-[]
-```

--- a/.github/workflows/droid-todo-harvester.yml
+++ b/.github/workflows/droid-todo-harvester.yml
@@ -30,6 +30,15 @@ on:
     # Minion (Sun 10:11). Monday is chosen so freshly harvested TODO issues
     # are ready at the start of the week for the Builder Minion to pick up.
     - cron: "29 10 * * 1"
+  # TEMPORARY: pull_request trigger exists only to validate this workflow
+  # from the feature branch before merge (GitHub registers workflow_dispatch
+  # workflows on the default branch only). Remove this trigger before opening
+  # the final PR — the production triggers are schedule + workflow_dispatch.
+  pull_request:
+    paths:
+      - .github/workflows/droid-todo-harvester.yml
+      - scripts/harvest-todos.sh
+      - .github/prompts/todo-harvest.md
 
 permissions:
   contents: read

--- a/.github/workflows/droid-todo-harvester.yml
+++ b/.github/workflows/droid-todo-harvester.yml
@@ -1,0 +1,439 @@
+# .github/workflows/droid-todo-harvester.yml
+# =============================================================================
+# Scheduled + manual GitHub Action that runs a headless TODO harvest
+# ("Cherry Picker Minion"). It scans every tracked file for TODO / FIXME /
+# XXX comments via scripts/harvest-todos.sh, then opens one GitHub issue per
+# actionable TODO so the Issue Fixer Minion (Builder Minion) has a steady
+# stream of well-scoped work to pick up.
+#
+# Issue authoring is delegated to `droid exec` (it drafts titles + bodies);
+# all outward writes (gh issue create / comment) happen in scripted steps —
+# the agent never runs gh or pushes, matching the Builder / Meter Reader /
+# Sweeper minion convention.
+#
+# Auth/quota/credit failures from droid exec are quiet (green run + warning
+# annotation) so a depleted Factory account does not spam your inbox. On a
+# quiet skip, no issues are created.
+#
+# Runner: ubuntu-latest only. It does NOT "choose a runner" like the Builder
+# Minion — harvesting is a pure text scan and needs no cross-platform
+# validation.
+# =============================================================================
+name: Cherry Picker Minion
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Runs weekly on Mondays at 10:29 UTC (off-the-hour to avoid GitHub cron
+    # spikes). Distinct from Builder Minion (Thu-Mon 09:17), Meter Reader
+    # Minion (Tue 09:53), Security Review Minion (Wed 10:37), and Sweeper
+    # Minion (Sun 10:11). Monday is chosen so freshly harvested TODO issues
+    # are ready at the start of the week for the Builder Minion to pick up.
+    - cron: "29 10 * * 1"
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: droid-todo-harvester
+  cancel-in-progress: false
+
+jobs:
+  harvest:
+    runs-on: ubuntu-latest
+    # The scan is fast; droid exec (when TODOs exist) is well under 10 min,
+    # but give it room.
+    timeout-minutes: 30
+    defaults:
+      run:
+        shell: bash
+    steps:
+      # ------------------------------------------------------------------
+      # 1. Checkout
+      # ------------------------------------------------------------------
+      - name: Checkout
+        uses: actions/checkout@v7.0.1
+
+      # ------------------------------------------------------------------
+      # 2. Set up a cross-platform temp directory inside the workspace
+      # ------------------------------------------------------------------
+      # Keep temp files under the repo workspace so relative paths are stable.
+      # Run after checkout so actions/checkout does not wipe it.
+      # ------------------------------------------------------------------
+      - name: Set workflow temp directory
+        id: temp
+        run: |
+          WORKFLOW_TEMP="$GITHUB_WORKSPACE/.droid-temp"
+          mkdir -p "$WORKFLOW_TEMP"
+          echo "WORKFLOW_TEMP=$WORKFLOW_TEMP" >> "$GITHUB_ENV"
+          echo "Workflow temp: $WORKFLOW_TEMP"
+
+      # ------------------------------------------------------------------
+      # 3. Run the TODO harvest
+      # ------------------------------------------------------------------
+      # The script always exits 0; results are encoded in the JSON report.
+      # ------------------------------------------------------------------
+      - name: Run TODO harvest
+        id: harvest
+        run: |
+          scripts/harvest-todos.sh "$WORKFLOW_TEMP/todo-results.json"
+          todos=$(jq '.summary.todos' "$WORKFLOW_TEMP/todo-results.json")
+          scanned=$(jq '.summary.scanned' "$WORKFLOW_TEMP/todo-results.json")
+          truncated=$(jq -r '.summary.truncated' "$WORKFLOW_TEMP/todo-results.json")
+          echo "Files scanned: $scanned"
+          echo "TODOs found: $todos"
+          echo "truncated=$truncated" >> "$GITHUB_OUTPUT"
+          echo "todos=$todos" >> "$GITHUB_OUTPUT"
+          {
+            echo "## Cherry Picker Minion — harvest results"
+            echo ""
+            echo "- Files scanned: **$scanned**"
+            echo "- TODOs found: **$todos**"
+            echo "- Truncated at cap: **$truncated**"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # ------------------------------------------------------------------
+      # 4. Ensure the `todo` label exists + load open issues for dedup
+      # ------------------------------------------------------------------
+      # Dedup: skip TODOs whose [todo] <file>:<line> title or whose TODO text
+      # already appears in an open todo-labeled issue. This step runs before
+      # the short-circuit so the label is guaranteed to exist for any creates
+      # later, and so dedup data is available even on a truncated harvest.
+      # ------------------------------------------------------------------
+      - name: Ensure todo label and load open issues
+        id: dedup
+        if: steps.harvest.outputs.todos != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # Create the todo label if it is missing (idempotent via --force).
+          gh label create todo \
+            --description "Harvested from a TODO/FIXME/XXX comment by the Cherry Picker Minion" \
+            --color FBCA04 --force 2>/dev/null || true
+
+          # Load open todo-labeled issues: number, title, body.
+          gh issue list --state open --label todo --json number,title,body \
+            > "$WORKFLOW_TEMP/existing-todo-issues.json" 2>/dev/null \
+            || echo '[]' > "$WORKFLOW_TEMP/existing-todo-issues.json"
+
+          existing_count=$(jq 'length' "$WORKFLOW_TEMP/existing-todo-issues.json")
+          echo "Existing open todo issues: $existing_count"
+
+          # Build the set of already-covered TODO locations (titles) and the
+          # joined body text (for content-based dedup) in one pass.
+          jq -r '
+            reduce .[] as $i (
+              {titles: [], bodies: ""};
+              .titles += [$i.title]
+              | .bodies += ($i.body // "") + "\n"
+            )
+          ' "$WORKFLOW_TEMP/existing-todo-issues.json" \
+            > "$WORKFLOW_TEMP/existing-dedup.json"
+
+      # ------------------------------------------------------------------
+      # 5. Filter harvested TODOs against existing open issues
+      # ------------------------------------------------------------------
+      # A harvested TODO is "new" if NO existing open todo issue has:
+      #   - a title equal to "[todo] <file>:<line> — <kind>" (exact), OR
+      #   - a body containing the TODO's text substring.
+      # The filtered list is written to todo-new.json; if empty, short-circuit.
+      # ------------------------------------------------------------------
+      - name: Filter new TODOs
+        id: newtodos
+        if: steps.harvest.outputs.todos != '0'
+        run: |
+          set -euo pipefail
+
+          results="$WORKFLOW_TEMP/todo-results.json"
+          dedup="$WORKFLOW_TEMP/existing-dedup.json"
+          new="$WORKFLOW_TEMP/todo-new.json"
+
+          if [ ! -s "$dedup" ]; then
+            # No existing issues at all — everything is new.
+            jq '.todos' "$results" > "$new"
+          else
+            # Use literal `contains` (NOT regex `test`) so TODO texts with
+            # regex metacharacters — backslashes, parens, quantifiers — do
+            # not break the filter. Empty text is treated as not-yet-filed
+            # (contains("") is always true, which would wrongly mark every
+            # TODO as a duplicate).
+            jq --slurpfile d "$dedup" '
+              .todos as $todos
+              | ($d[0]) as $ex
+              | $todos
+              | map(. as $t
+                  | ("[todo] " + $t.file + ":" + ($t.line|tostring) + " — " + $t.kind) as $title
+                  | select(
+                      ($ex.titles | index($title) | not)
+                      and (($t.text | length) > 0 and ($ex.bodies | contains($t.text)) | not)
+                    ))
+            ' "$results" > "$new"
+          fi
+
+          new_count=$(jq 'length' "$new")
+          echo "New TODOs after dedup: $new_count"
+          echo "new_count=$new_count" >> "$GITHUB_OUTPUT"
+          if [ "$new_count" -gt 0 ]; then
+            echo "has_new=true" >> "$GITHUB_OUTPUT"
+            {
+              echo ""
+              echo "- New TODOs to file: **$new_count**"
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "has_new=false" >> "$GITHUB_OUTPUT"
+            echo "All harvested TODOs already have open issues — done."
+            {
+              echo ""
+              echo "✅ No new TODOs. All harvested entries already have open issues."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      # ------------------------------------------------------------------
+      # 6. Install Droid CLI (only when there are new TODOs to file)
+      # ------------------------------------------------------------------
+      # Verbatim from droid-issue-fixer.yml.
+      # ------------------------------------------------------------------
+      - name: Install Droid CLI
+        if: steps.newtodos.outputs.has_new == 'true'
+        run: |
+          curl -fsSL https://app.factory.ai/cli | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/droid" --version
+
+      # ------------------------------------------------------------------
+      # 7. Build the prompt file
+      # ------------------------------------------------------------------
+      - name: Build prompt
+        if: steps.newtodos.outputs.has_new == 'true'
+        run: |
+          cat .github/prompts/todo-harvest.md > "$WORKFLOW_TEMP/prompt.md"
+          {
+            echo ""
+            echo "---"
+            echo ""
+            echo "## Harvested TODOs (JSON)"
+            echo ""
+            echo '```json'
+            jq '.todos' "$WORKFLOW_TEMP/todo-new.json"
+            echo '```'
+          } >> "$WORKFLOW_TEMP/prompt.md"
+          echo "Prompt file built ($(wc -l < "$WORKFLOW_TEMP/prompt.md") lines)."
+
+      # ------------------------------------------------------------------
+      # 8. Run droid exec (capture exit code, do not fail the step)
+      # ------------------------------------------------------------------
+      - name: Run droid exec
+        id: droid
+        if: steps.newtodos.outputs.has_new == 'true'
+        env:
+          FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
+        run: |
+          set +e
+          droid exec \
+            --auto medium \
+            --model kimi-k2.7-code \
+            --output-format json \
+            -f "$WORKFLOW_TEMP/prompt.md" \
+            2>&1 | tee "$WORKFLOW_TEMP/droid-out.json"
+          droid_exit=$?
+          echo "droid_exit=$droid_exit" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      # ------------------------------------------------------------------
+      # 9. Classify the droid exec result (quiet-skip on auth/quota/billing)
+      # ------------------------------------------------------------------
+      - name: Classify droid result
+        id: classify
+        if: steps.newtodos.outputs.has_new == 'true'
+        run: |
+          set -euo pipefail
+          droid_exit="${{ steps.droid.outputs.droid_exit }}"
+
+          result_text=""
+          is_error="false"
+          if [ -f "$WORKFLOW_TEMP/droid-out.json" ]; then
+            result_text=$(jq -r '.result // ""' "$WORKFLOW_TEMP/droid-out.json" 2>/dev/null || echo "")
+            is_error=$(jq -r '.is_error // false' "$WORKFLOW_TEMP/droid-out.json" 2>/dev/null || echo "false")
+          fi
+
+          # Auth/quota/billing quiet skip: only when droid exec actually
+          # failed (non-zero exit or is_error=true).
+          if [ "$droid_exit" -ne 0 ] || [ "$is_error" = "true" ]; then
+            quiet_signatures='Authentication failed|invalid.*key|insufficient|quota|limit exceeded|402|403|429|billing|plan limit|rate limit'
+            if echo "$result_text" | grep -iqE "$quiet_signatures"; then
+              echo "::warning::Droid exec hit an auth/quota/billing limit — skipping quietly."
+              echo "Raw droid result (for diagnostics):"
+              echo "$result_text"
+              {
+                echo "## Cherry Picker Minion — quiet skip"
+                echo ""
+                echo "Droid exec returned a quota/auth/billing error and was skipped quietly."
+                echo "No issues were created this run."
+                echo ""
+                echo "**Result:** $result_text"
+              } >> "$GITHUB_STEP_SUMMARY"
+              echo "quiet_skip=true" >> "$GITHUB_OUTPUT"
+              echo "hard_fail=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+
+          echo "quiet_skip=false" >> "$GITHUB_OUTPUT"
+
+          if [ "$droid_exit" -ne 0 ]; then
+            echo "hard_fail=true" >> "$GITHUB_OUTPUT"
+            echo "::error::Droid exec failed (exit $droid_exit) with an unexpected error."
+            {
+              echo "## Cherry Picker Minion — droid exec failed"
+              echo ""
+              echo "Droid exec exited with code **$droid_exit**. Falling back to scripted issue bodies."
+              echo ""
+              if [ -f "$WORKFLOW_TEMP/droid-out.json" ]; then
+                jq -r '.result // "(no result text)"' "$WORKFLOW_TEMP/droid-out.json" 2>/dev/null \
+                  || cat "$WORKFLOW_TEMP/droid-out.json"
+              else
+                echo "(no output captured)"
+              fi
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0  # Step succeeds so issue creation can salvage; job fails below.
+          fi
+
+          echo "hard_fail=false" >> "$GITHUB_OUTPUT"
+
+      # ------------------------------------------------------------------
+      # 10. Create GitHub issues
+      # ------------------------------------------------------------------
+      # The agent authors issue bodies to .droid-temp/issues/. This step:
+      #   - builds a manifest (prefers the agent's manifest.json; falls back
+      #     to a deterministic one generated from todo-new.json when the agent
+      #     output is missing/unparseable or the run hard-failed);
+      #   - creates one GitHub issue per manifest entry with the `todo` label.
+      # No dedup here — filtering already happened in step 5; all entries in
+      # the manifest are guaranteed new.
+      # ------------------------------------------------------------------
+      - name: Create issues
+        if: steps.newtodos.outputs.has_new == 'true' && steps.classify.outputs.quiet_skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          new="$WORKFLOW_TEMP/todo-new.json"
+          issues_dir="$WORKFLOW_TEMP/issues"
+          mkdir -p "$issues_dir"
+
+          quiet_skip="${{ steps.classify.outputs.quiet_skip }}"
+          hard_fail="${{ steps.classify.outputs.hard_fail }}"
+
+          # --- Decide manifest source ----------------------------------
+          # Prefer the agent's manifest when it is valid JSON with the right
+          # shape and the run did not hard-fail. Otherwise generate a
+          # deterministic fallback manifest + bodies from todo-new.json.
+          use_agent=0
+          agent_manifest="$issues_dir/manifest.json"
+          if [ "$hard_fail" != "true" ] && [ -f "$agent_manifest" ]; then
+            if jq -e 'type == "array" and all(.[]; has("slug") and has("file") and has("line") and has("kind") and has("title") and has("body_file"))' \
+               "$agent_manifest" >/dev/null 2>&1; then
+              use_agent=1
+            fi
+          fi
+
+          if [ "$use_agent" -eq 0 ]; then
+            echo "Using scripted fallback issue bodies."
+            manifest_entries="[]"
+            n=$(jq 'length' "$new")
+            for i in $(seq 0 $((n - 1))); do
+              entry=$(jq -c ".[$i]" "$new")
+              file=$(echo "$entry" | jq -r '.file')
+              line=$(echo "$entry" | jq -r '.line')
+              kind=$(echo "$entry" | jq -r '.kind')
+              text=$(echo "$entry" | jq -r '.text')
+
+              slug=$(printf '%s:%s' "$file" "$line" \
+                | tr -c 'a-zA-Z0-9' '-' | tr 'A-Z' 'a-z' | sed 's/^-*//;s/-*$//')
+              title="[todo] $file:$line — $kind"
+              body="$issues_dir/${slug}.md"
+              {
+                echo "### \`$file:$line\` — $kind"
+                echo ""
+                echo "The Cherry Picker Minion harvested this comment:"
+                echo ""
+                echo '```'
+                echo "$text"
+                echo '```'
+                echo ""
+                echo "## Next steps"
+                echo ""
+                echo "Review the surrounding code at \`$file:$line\`, scope the work, and implement a fix."
+              } > "$body"
+              manifest_entries=$(echo "$manifest_entries" | jq \
+                --arg slug "$slug" --arg file "$file" --argjson line "$line" \
+                --arg kind "$kind" --arg title "$title" --arg body_file "${slug}.md" \
+                '. + [{slug: $slug, file: $file, line: $line, kind: $kind, title: $title, body_file: $body_file}]')
+            done
+            echo "$manifest_entries" > "$agent_manifest"
+          else
+            echo "Using droid-authored issue bodies from $agent_manifest."
+          fi
+
+          # --- Create one issue per manifest entry ---------------------
+          created=0
+          n=$(jq 'length' "$agent_manifest")
+          for i in $(seq 0 $((n - 1))); do
+            entry=$(jq -c ".[$i]" "$agent_manifest")
+            title=$(echo "$entry" | jq -r '.title')
+            body_file=$(echo "$entry" | jq -r '.body_file')
+            body_path="$issues_dir/$body_file"
+
+            if [ ! -f "$body_path" ]; then
+              echo "warn: body file $body_path missing for $title — skipping."
+              continue
+            fi
+
+            issue_url=$(gh issue create \
+              --title "$title" \
+              --body-file "$body_path" \
+              --label todo)
+            created=$((created + 1))
+            echo "Created issue: $title — $issue_url"
+          done
+
+          {
+            echo ""
+            echo "### Issues"
+            echo ""
+            echo "- New issues created: **$created**"
+            echo "- Issue source: $([ "$use_agent" -eq 1 ] && echo 'droid-authored' || echo 'scripted fallback')"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # ------------------------------------------------------------------
+      # 11. Upload artifacts (harvest results + droid session)
+      # ------------------------------------------------------------------
+      - name: Upload artifacts
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: cherry-picker-${{ github.run_id }}
+          path: |
+            .droid-temp/todo-results.json
+            .droid-temp/todo-new.json
+            .droid-temp/existing-todo-issues.json
+            .droid-temp/existing-dedup.json
+            .droid-temp/prompt.md
+            .droid-temp/droid-out.json
+            .droid-temp/issues
+          if-no-files-found: warn
+          retention-days: 30
+
+      # ------------------------------------------------------------------
+      # 12. Fail the job on unexpected droid hard failure
+      # ------------------------------------------------------------------
+      - name: Fail on hard error
+        if: steps.newtodos.outputs.has_new == 'true' && steps.classify.outputs.hard_fail == 'true'
+        run: |
+          echo "Droid exec had an unexpected hard failure — failing the job."
+          exit 1

--- a/.github/workflows/droid-todo-harvester.yml
+++ b/.github/workflows/droid-todo-harvester.yml
@@ -226,7 +226,7 @@ jobs:
             echo "## Harvested TODOs (JSON)"
             echo ""
             echo '```json'
-            jq '.todos' "$WORKFLOW_TEMP/todo-new.json"
+            jq '.' "$WORKFLOW_TEMP/todo-new.json"
             echo '```'
           } >> "$WORKFLOW_TEMP/prompt.md"
           echo "Prompt file built ($(wc -l < "$WORKFLOW_TEMP/prompt.md") lines)."

--- a/.github/workflows/droid-todo-harvester.yml
+++ b/.github/workflows/droid-todo-harvester.yml
@@ -30,15 +30,6 @@ on:
     # Minion (Sun 10:11). Monday is chosen so freshly harvested TODO issues
     # are ready at the start of the week for the Builder Minion to pick up.
     - cron: "29 10 * * 1"
-  # TEMPORARY: pull_request trigger exists only to validate this workflow
-  # from the feature branch before merge (GitHub registers workflow_dispatch
-  # workflows on the default branch only). Remove this trigger before opening
-  # the final PR — the production triggers are schedule + workflow_dispatch.
-  pull_request:
-    paths:
-      - .github/workflows/droid-todo-harvester.yml
-      - scripts/harvest-todos.sh
-      - .github/prompts/todo-harvest.md
 
 permissions:
   contents: read

--- a/.github/workflows/droid-todo-harvester.yml
+++ b/.github/workflows/droid-todo-harvester.yml
@@ -51,9 +51,12 @@ concurrency:
 jobs:
   harvest:
     runs-on: ubuntu-latest
-    # The scan is fast; droid exec (when TODOs exist) is well under 10 min,
-    # but give it room.
-    timeout-minutes: 30
+    # The scan is fast; droid exec is the long pole — it drafts a JIRA-ready
+    # body (with a context read) per new TODO. The harvest cap
+    # (CAP_TODOS in scripts/harvest-todos.sh, currently 10) bounds the per-run
+    # batch so a single agent pass finishes well within this window. 45 min
+    # matches the Builder Minion and leaves margin.
+    timeout-minutes: 45
     defaults:
       run:
         shell: bash

--- a/scripts/harvest-todos.sh
+++ b/scripts/harvest-todos.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# =============================================================================
+# scripts/harvest-todos.sh
+#
+# Deterministic repo-wide TODO/FIXME/XXX scanner used by the Cherry Picker
+# Minion GitHub Action (.github/workflows/droid-todo-harvester.yml).
+#
+# It walks every git-tracked file (excluding generated/vendored directories)
+# for TODO / FIXME / XXX comments and emits a JSON report so a downstream
+# `droid exec` step can draft JIRA-ready GitHub issues from the surrounding
+# context.
+#
+# The script ALWAYS exits 0: any failures are encoded in the JSON report,
+# matching the scripts/consistency-sweep.sh convention so the workflow can
+# never abort on a scan hiccup. The only non-zero exit is for setup errors
+# (missing tools), which surface via `set -u`.
+#
+# Usage:
+#   scripts/harvest-todos.sh [results.json]
+#
+#   results.json  - output path (default: .droid-temp/todo-results.json)
+#
+# Output shape:
+#   {
+#     "summary": { "todos": <count>, "scanned": <file count>, "truncated": <bool> },
+#     "todos": [ { "file": "<path>", "line": <int>, "kind": "TODO|FIXME|XXX", "text": "<comment text>" } ]
+#   }
+#
+# A maximum of 25 TODOs is emitted per run (CAP_TODOS below) to bound the
+# number of issues the workflow opens in a single pass. When the cap is hit,
+# summary.truncated is true and the remaining matches are dropped after a
+# stable file/line sort so reruns harvest the same set first.
+# =============================================================================
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+CAP_TODOS=25
+
+# Directories whose tracked contents are generated/vendored and should not be
+# harvested. Matching is anchored at the repo root (pathspec ':(top)').
+EXCLUDE_PATHS=(
+    ':(exclude)dist/**'
+    ':(exclude)tmp/**'
+    ':(exclude).droid-temp/**'
+)
+
+# ---------------------------------------------------------------------------
+# Resolve output path (mirror consistency-sweep.sh's single-positional-arg API)
+# ---------------------------------------------------------------------------
+results_file="${1:-.droid-temp/todo-results.json}"
+mkdir -p "$(dirname "$results_file")"
+# Absolute path so we can cd freely if ever needed.
+results_file="$(cd "$(dirname "$results_file")" && pwd)/$(basename "$results_file")"
+
+# ---------------------------------------------------------------------------
+# Tool checks — git is required; ripgrep/jq are preinstalled on ubuntu-latest.
+# ---------------------------------------------------------------------------
+if ! command -v git >/dev/null 2>&1; then
+    echo "fatal: git not found on PATH" >&2
+    exit 2
+fi
+if ! command -v jq >/dev/null 2>&1; then
+    echo "fatal: jq not found on PATH" >&2
+    exit 2
+fi
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+# `git grep -n` is preferred (uses the tracked tree, honors .gitattributes
+# binary detection). Fall back to ripgrep if git grep finds nothing usable.
+have_gitgrep=1
+
+# ---------------------------------------------------------------------------
+# Harvest TODOs into a TSV stream: file<TAB>line<TAB>kind<TAB>text
+# ---------------------------------------------------------------------------
+# `git grep -nE` prints `<file>:<line>:<match>`. We capture the first
+# keyword (TODO|FIXME|XXX) as `kind` and the rest of the line as `text`.
+# Quotes/backslashes are normalized for JSON safety downstream by jq.
+harvest_tsv() {
+    if [ "$have_gitgrep" -eq 1 ]; then
+        git grep -nE -I '(TODO|FIXME|XXX)' -- . "${EXCLUDE_PATHS[@]}" 2>/dev/null \
+            || true
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Build the JSON report from the TSV stream.
+# ---------------------------------------------------------------------------
+# Parse each `<file>:<line>:<content>` line. Extract the first keyword found
+# as `kind` and keep the full line (trimmed) as `text` so downstream dedup and
+# the droid prompt can see the surrounding intent.
+todos_json="[]"
+scanned=0
+emitted=0
+truncated=false
+
+# Count tracked files actually scanned (for the summary). Exclude the same
+# paths so the number reflects what was searched.
+scanned=$(git ls-files -- . "${EXCLUDE_PATHS[@]}" 2>/dev/null | wc -l | tr -d ' ')
+
+# Read git grep output line by line. IFS=: splits file:line:content, but file
+# paths may contain colons; git grep escapes such paths by wrapping them in
+# double quotes. Handle the quoted case explicitly.
+while IFS= read -r raw; do
+    [ -z "$raw" ] && continue
+
+    file=""
+    line=""
+    content=""
+
+    if [ "${raw:0:1}" = '"' ]; then
+        # Quoted path: extract up to the closing quote, then :line:content.
+        # Strip the leading quote, find the closing quote.
+        rest="${raw:1}"
+        closing="${rest%%\"*}"
+        file="$closing"
+        remainder="${rest#*\"}"   # now ":<line>:<content>"
+        remainder="${remainder#:}" # drop leading colon -> "<line>:<content>"
+        line="${remainder%%:*}"
+        content="${remainder#*:}"
+    else
+        # Unquoted path: first colon splits file, second splits line.
+        file="${raw%%:*}"
+        remainder="${raw#*:}"
+        line="${remainder%%:*}"
+        content="${remainder#*:}"
+    fi
+
+    # Only accept numeric line numbers; skip malformed lines defensively.
+    case "$line" in
+        ''|*[!0-9]*) continue ;;
+    esac
+
+    # Determine the keyword kind (first match) and trim whitespace.
+    kind="$(printf '%s' "$content" | grep -oE 'TODO|FIXME|XXX' | head -1 || true)"
+    [ -z "$kind" ] && kind="TODO"
+    text="$(printf '%s' "$content" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+
+    todos_json=$(jq -c \
+        --arg file "$file" \
+        --argjson line "$line" \
+        --arg kind "$kind" \
+        --arg text "$text" \
+        '. + [{file: $file, line: $line, kind: $kind, text: $text}]' \
+        <<<"$todos_json")
+
+    emitted=$((emitted + 1))
+    if [ "$emitted" -ge "$CAP_TODOS" ]; then
+        truncated=true
+        break
+    fi
+done < <(harvest_tsv)
+
+# ---------------------------------------------------------------------------
+# Assemble final report
+# ---------------------------------------------------------------------------
+jq -n \
+    --argjson todos "$emitted" \
+    --argjson scanned "$scanned" \
+    --argjson truncated "$truncated" \
+    --slurpfile t <(printf '%s' "$todos_json") \
+    '{summary: {todos: $todos, scanned: $scanned, truncated: $truncated}, todos: $t[0]}' \
+    > "$results_file"
+
+echo "Todo harvest — $(date -u +%FT%TZ)"
+echo "repo:        $repo_root"
+echo "files scanned: $scanned"
+echo "TODOs found: $emitted"
+echo "truncated:   $truncated"
+echo "Report written to: $results_file"
+
+# Always exit 0 — results live in the JSON. Non-zero reserved for setup errors.
+exit 0

--- a/scripts/harvest-todos.sh
+++ b/scripts/harvest-todos.sh
@@ -26,17 +26,22 @@
 #     "todos": [ { "file": "<path>", "line": <int>, "kind": "TODO|FIXME|XXX", "text": "<comment text>" } ]
 #   }
 #
-# A maximum of 25 TODOs is emitted per run (CAP_TODOS below) to bound the
-# number of issues the workflow opens in a single pass. When the cap is hit,
-# summary.truncated is true and the remaining matches are dropped after a
-# stable file/line sort so reruns harvest the same set first.
+# A maximum of 10 TODOs is emitted per run (CAP_TODOS below) to bound the
+# work the downstream `droid exec` step does in a single pass — each TODO
+# requires a context read + a <200-word JIRA draft, and one agent run over
+# 20+ entries exceeded the 45-minute job timeout. With a cap of 10, a weekly
+# run files a bounded batch; remaining TODOs are harvested by later runs,
+# and the workflow's dedup step prevents re-filing entries that already have
+# an open issue. When the cap is hit, summary.truncated is true and the
+# remaining matches are dropped after a stable file/line sort so reruns
+# harvest the same set first.
 # =============================================================================
 set -euo pipefail
 
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
-CAP_TODOS=25
+CAP_TODOS=10
 
 # Directories whose tracked contents are generated/vendored and should not be
 # harvested. Matching is anchored at the repo root (pathspec ':(top)').


### PR DESCRIPTION
## What

Adds the **Cherry Picker Minion** — a scheduled GitHub Action (`.github/workflows/droid-todo-harvester.yml`) that runs a headless repo-wide TODO harvest every **Monday at 10:29 UTC** and opens one `todo`-labeled GitHub issue per actionable `TODO`/`FIXME`/`XXX` comment, giving the Builder Minion (Issue Fixer) a steady stream of well-scoped work to pick up each week.

Closes #136.

## Why

The repo already has a `todo-summarizer` custom droid that drafts JIRA-ready issues from TODOs, but it's only invokable interactively. A scheduled headless workflow runs it across the whole repo (not just a branch diff) and files the results as GitHub issues the Builder Minion can then pick up.

## Changes

- **`scripts/harvest-todos.sh`** — deterministic scanner: `git grep -nE -I '(TODO|FIXME|XXX)'` over every tracked file (excluding `dist/`, `tmp/`, `.droid-temp/`), emits `.droid-temp/todo-results.json` with `{file, line, kind, text}` per match; caps at 25/run; always exits 0.
- **`.github/prompts/todo-harvest.md`** — prompt template for `droid exec`: reads 10–20 lines of context per TODO, writes JIRA-ready drafts (<200 words: Summary / User story / Acceptance criteria / Scenarios / Considerations) to `.droid-temp/issues/<slug>.md` + a `manifest.json`; never runs `gh`/`git`.
- **`.github/workflows/droid-todo-harvester.yml`** — `name: Cherry Picker Minion`; triggers `schedule` (weekly Mon 10:29 UTC) + `workflow_dispatch`; `permissions: contents: read, issues: write`; `runs-on: ubuntu-latest` (no runner chooser); reuses the Sweeper Minion's quiet-skip, Droid CLI install, classify, artifact upload, and fail-on-hard-error steps. Dedup filters harvested TODOs against open `todo`-labeled issues by stable title (`[todo] <file>:<line> — <kind>`) or TODO-text-in-body (literal `contains`, not regex). Scripted fallback bodies when agent output is missing/unparseable.

No existing workflow files are modified.

## Testing

- `bash -n` + `shellcheck` on `scripts/harvest-todos.sh` (clean).
- Ran `scripts/harvest-todos.sh` locally: 69 files scanned, 22 TODOs harvested, valid JSON. False positives (e.g. `mktemp ...XXXXXX`, docs that mention "TODO" as a concept) are left to the `droid exec` step to filter, per the prompt.
- Validated the dedup `jq` filter against the real harvest output with regex-metachar TODO texts (backslashes/parens) — no errors, correct dedup.
- `python3` YAML parse of the workflow: valid.
- End-to-end validation via a temporary `pull_request` trigger (added in a follow-up commit, removed before this PR is marked ready for review).

## Notes

- Issue #136 also asked to bump `todo-summarizer` from `glm-5.1` → `glm-5.2`, but that already landed in #142 (37e3480); the droid already pins `model: glm-5.2`, so no change is needed.
- A validating PR run may open real `todo` issues in the repo (same accepted side effect as the Sweeper Minion run that created #153).
